### PR TITLE
Use tox to be able to run tests locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ virtualenv*
 .eggs
 .coverage
 .pytest_cache
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: python
-python:
-    - "3.6"
-    - "3.7"
+matrix:
+  include:
+  - python: 3.6
+    env: TOX_ENV=py36
+  - python: 3.7
+    env: TOX_ENV=py37
+  - python: 3.7
+    env: TOX_ENV=lint
 install:
-    - pip install -r requirements.txt
+- pip install tox
 script:
-    - pytest -s --cov -vv
-    - pylint ceph_bootstrap
-    - pycodestyle ceph_bootstrap
-    # linting tests code
-    - pylint tests
-    - pycodestyle tests
-
+- tox -e $TOX_ENV
 after_success:
     - codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist = py36,py37,lint
+minversion = 2.0
+skipsdist = True
+
+[testenv]
+usedevelop = True
+install_command = pip install {opts} {packages}
+deps =
+  -r{toxinidir}/requirements.txt
+commands = pytest {posargs:-s --cov -vv}
+
+[testenv:lint]
+basepython = python3
+deps = {[testenv]deps}
+commands =
+  pylint ceph_bootstrap
+  pycodestyle ceph_bootstrap
+  pylint tests
+  pycodestyle tests


### PR DESCRIPTION
With tox, it's easy to run unittests or linters locally before
submitting code. So use it here.
Also switch Travis to use tox, too. That way the results between local
test runs and travis runs are more compareable.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>