### PR TITLE
configshell: Fix help command when help text is not provided

### DIFF
--- a/ceph_bootstrap/config_shell.py
+++ b/ceph_bootstrap/config_shell.py
@@ -470,7 +470,7 @@ class OptionNode(configshell.ConfigNode):
         configshell.ConfigNode.__init__(self, option_name, parent)
         self.option_name = option_name
         self.option_dict = option_dict
-        self.help_intro = option_dict.get('help', '')
+        self.help_intro = option_dict.get('help', ' ')
         self.value = None
 
     def _list_commands(self):


### PR DESCRIPTION

![Screenshot from 2020-01-08 10-00-24](https://user-images.githubusercontent.com/14297426/71968958-b74d3a00-31fd-11ea-8f9c-7eff01f68ec3.png)


Signed-off-by: Ricardo Marques <rimarques@suse.com>