### PR TITLE
configshell: Removing the last MON must remove "bootstrap_mon"

### DIFF
--- a/ceph_bootstrap/core.py
+++ b/ceph_bootstrap/core.py
@@ -80,6 +80,8 @@ class CephNodeManager:
         minions.sort()
         if minions:  # i.e., it has at least one
             PillarManager.set('ceph-salt:bootstrap_mon', minions[0])
+        else:
+            PillarManager.reset('ceph-salt:bootstrap_mon')
 
     @classmethod
     def ceph_salt_nodes(cls):


### PR DESCRIPTION
Fixes: https://github.com/SUSE/ceph-bootstrap/issues/17

Signed-off-by: Ricardo Marques <rimarques@suse.com>