### PR TITLE
configshell: Remove minions only if no error is thrown

### DIFF
--- a/ceph_bootstrap/config_shell.py
+++ b/ceph_bootstrap/config_shell.py
@@ -648,8 +648,10 @@ class MinionsOptionNode(OptionNode):
         counter = 0
         for match in matching:
             if match not in self.value:
-                self.value.append(match)
-                self.option_dict['handler'].save(self.value)
+                new_value = list(self.value)
+                new_value.append(match)
+                self.option_dict['handler'].save(new_value)
+                self.value = new_value
                 MinionOptionNode(match, self.option_dict['handler'].children_handler(match), self)
                 counter += 1
         if counter == 1:
@@ -662,8 +664,10 @@ class MinionsOptionNode(OptionNode):
     def ui_command_rm(self, minion_id):
         matching = fnmatch.filter(self.value, minion_id)
         for match in matching:
-            self.value.remove(match)
-            self.option_dict['handler'].save(self.value)
+            new_value = list(self.value)
+            new_value.remove(match)
+            self.option_dict['handler'].save(new_value)
+            self.value = new_value
             self.remove_child(self.get_child(match))
         counter = len(matching)
         if counter == 1:

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -1,3 +1,4 @@
+from ceph_bootstrap.exceptions import CephNodeHasRolesException
 from ceph_bootstrap.salt_utils import GrainsManager, PillarManager
 from ceph_bootstrap.config_shell import CephBootstrapConfigShell, generate_config_shell_tree
 
@@ -34,6 +35,16 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), [])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {})
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_mon'), None)
+
+    def test_cluster_minions_rm_with_role(self):
+        self.shell.run_cmdline('/Cluster/Minions add node1.ceph.com')
+        self.shell.run_cmdline('/Cluster/Roles/Mgr add node1.ceph.com')
+
+        with self.assertRaises(CephNodeHasRolesException):
+            self.shell.run_cmdline('/Cluster/Minions rm node1.ceph.com')
+
+        self.shell.run_cmdline('/Cluster/Roles/Mgr rm node1.ceph.com')
+        self.shell.run_cmdline('/Cluster/Minions rm node1.ceph.com')
 
     def test_cluster_roles_mgr(self):
         self.shell.run_cmdline('/Cluster/Minions add node1.ceph.com')


### PR DESCRIPTION
Fixes: https://github.com/SUSE/ceph-bootstrap/issues/24

Signed-off-by: Ricardo Marques <rimarques@suse.com>