### PR TITLE
qa: initial integration testing script

### DIFF
--- a/ceph-bootstrap.spec
+++ b/ceph-bootstrap.spec
@@ -28,7 +28,7 @@ License:        MIT
 %if 0%{?suse_version}
 Group:          System/Management
 %endif
-URL:            https://github.com/SUSE/ceph-bootstrap
+URL:            https://github.com/SUSE/%{name}
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
@@ -52,19 +52,33 @@ Requires:       python3-salt >= 2019.2.0
 Requires:       ceph-salt-formula
 Requires:       salt-master >= 2019.2.0
 
+
 %description
 ceph-bootstrap is a CLI tool for deploying Ceph clusters starting from version
 Octopus.
 
+
 %prep
 %autosetup -n %{name}-%{version} -p1
+
 
 %build
 %py3_build
 
+
 %install
 %py3_install
 %fdupes %{buildroot}%{python3_sitelib}
+install -m 0755 -d %{buildroot}/%{_datadir}/%{name}
+
+# qa script installation
+install -m 0755 -d %{buildroot}/%{_datadir}/%{name}/qa
+install -m 0755 -d %{buildroot}/%{_datadir}/%{name}/qa/common
+install -m 0755 qa/health-ok.sh %{buildroot}/%{_datadir}/%{name}/qa/health-ok.sh
+install -m 0644 qa/common/common.sh %{buildroot}/%{_datadir}/%{name}/qa/common/common.sh
+install -m 0644 qa/common/helper.sh %{buildroot}/%{_datadir}/%{name}/qa/common/helper.sh
+install -m 0644 qa/common/json.sh %{buildroot}/%{_datadir}/%{name}/qa/common/json.sh
+install -m 0644 qa/common/zypper.sh %{buildroot}/%{_datadir}/%{name}/qa/common/zypper.sh
 
 # ceph-salt-formula installation
 %define fname ceph-salt
@@ -98,11 +112,27 @@ pillar_roots:
 EOF
 
 
-%files -n ceph-bootstrap
+%files
 %license LICENSE
 %doc CHANGELOG.md README.md
 %{python3_sitelib}/ceph_bootstrap*/
-%{_bindir}/ceph-bootstrap
+%{_bindir}/%{name}
+%dir %{_datadir}/%{name}
+
+
+%package qa
+Summary:    Integration test script for ceph-bootstrap
+Group:      System/Management
+
+
+%description qa
+Integration test script for validating Ceph clusters deployed
+by ceph-bootstrap
+
+
+%files qa
+%{_datadir}/%{name}/qa
+
 
 %package -n ceph-salt-formula
 Summary:    Ceph Salt Formula
@@ -114,8 +144,10 @@ Requires(pre):  salt-formulas-configuration
 Requires(pre):  salt-master
 %endif
 
+
 %description -n ceph-salt-formula
 Salt Formula to deploy Ceph clusters.
+
 
 %files -n ceph-salt-formula
 %defattr(-,root,root,-)

--- a/qa/README.rst
+++ b/qa/README.rst
@@ -1,0 +1,46 @@
+health-ok.sh
+============
+
+ceph-bootstrap integration test automation script
+
+
+Overview
+--------
+
+This bash script contains integration tests for validating Ceph deployments
+done with ceph-bootstrap.
+
+The idea is to run this script with the appropriate arguments on the
+Salt Master node after using ceph-bootstrap to deploy a cluster.
+
+The script makes a number of assumptions, as listed under "Assumptions", below.
+
+On success (HEALTH_OK is reached, sanity tests pass), the script returns 0.
+On failure, for whatever reason, the script returns non-zero.
+
+The script produces verbose output on stdout, which can be captured for later
+forensic analysis.
+
+Though referred to as a bash script, ``health-ok.sh`` is only the entry point.
+That file uses the bash internal ``source`` to run several helper scripts, which
+are located in the ``common/`` subdirectory.
+
+
+Assumptions
+-----------
+
+The script makes the following assumptions:
+
+1. the script is being run on the Salt Master of a Ceph cluster deployed using
+   ceph-bootstrap
+2. the script is being run as root
+3. the Ceph admin keyring is installed in the usual way, so the root user can
+   see and use the keyring
+
+
+Caveats
+-------
+
+The following caveats apply:
+
+1. Ceph will not work properly unless the nodes have (at least) short hostnames. That means the health-ok.sh script won't pass, either. There are two options: ``/etc/hosts`` or DNS

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -1,0 +1,205 @@
+#
+# This file is part of the ceph-bootstrap integration test suite
+#
+
+set -e
+
+# BASEDIR is set by the calling script
+source $BASEDIR/common/helper.sh
+source $BASEDIR/common/json.sh
+source $BASEDIR/common/zypper.sh
+
+
+#
+# functions that process command-line arguments
+#
+
+function assert_enhanced_getopt {
+    set +e
+    echo -n "Running 'getopt --test'... "
+    getopt --test > /dev/null
+    if [ $? -ne 4 ]; then
+        echo "FAIL"
+        echo "This script requires enhanced getopt. Bailing out."
+        exit 1
+    fi
+    echo "PASS"
+    set -e
+}
+
+
+#
+# functions that print status information
+#
+
+function cat_salt_config {
+    cat /etc/salt/master
+    cat /etc/salt/minion
+}
+
+function salt_pillar_items {
+    salt '*' pillar.items
+}
+
+function salt_pillar_get_roles {
+    salt '*' pillar.get roles
+}
+
+function salt_cmd_run_lsblk {
+    salt '*' cmd.run lsblk
+}
+
+function cat_ceph_conf {
+    salt '*' cmd.run "cat /etc/ceph/ceph.conf" 2>/dev/null
+}
+
+function admin_auth_status {
+    ceph auth get client.admin
+    ls -l /etc/ceph/ceph.client.admin.keyring
+    cat /etc/ceph/ceph.client.admin.keyring
+}
+
+function number_of_hosts_in_ceph_osd_tree {
+    ceph osd tree -f json-pretty | jq '[.nodes[] | select(.type == "host")] | length'
+}
+
+function number_of_osds_in_ceph_osd_tree {
+    ceph osd tree -f json-pretty | jq '[.nodes[] | select(.type == "osd")] | length'
+}
+
+function ceph_cluster_status {
+    ceph pg stat -f json-pretty
+    _grace_period 1
+    ceph health detail -f json-pretty
+    _grace_period 1
+    ceph osd tree
+    _grace_period 1
+    ceph osd pool ls detail -f json-pretty
+    _grace_period 1
+    ceph -s
+}
+
+function ceph_log_grep_enoent_eaccess {
+    set +e
+    grep -rH "Permission denied" /var/log/ceph
+    grep -rH "No such file or directory" /var/log/ceph
+    set -e
+}
+
+
+#
+# core validation tests
+#
+
+function ceph_version_test {
+# test that ceph RPM version matches "ceph --version"
+# for a loose definition of "matches"
+    echo
+    echo "WWWW: ceph_version_test"
+    set -x
+    rpm -q ceph-common
+    set +x
+    local RPM_NAME=$(rpm -q ceph-common)
+    local RPM_CEPH_VERSION=$(perl -e '"'"$RPM_NAME"'" =~ m/ceph-common-(\d+\.\d+\.\d+)/; print "$1\n";')
+    echo "According to RPM, the ceph upstream version is ->$RPM_CEPH_VERSION<-"
+    test -n "$RPM_CEPH_VERSION"
+    set -x
+    ceph --version
+    set +x
+    local BUFFER=$(ceph --version)
+    local CEPH_CEPH_VERSION=$(perl -e '"'"$BUFFER"'" =~ m/ceph version (\d+\.\d+\.\d+)/; print "$1\n";')
+    echo "According to \"ceph --version\", the ceph upstream version is ->$CEPH_CEPH_VERSION<-"
+    test -n "$RPM_CEPH_VERSION"
+    set -x
+    test "$RPM_CEPH_VERSION" = "$CEPH_CEPH_VERSION"
+    set +x
+    echo "ceph_version_test: OK"
+    echo
+}
+
+function ceph_cluster_running_test {
+    echo
+    echo "WWWW: ceph_cluster_running_test"
+    _ceph_cluster_running
+}
+
+function ceph_health_test {
+# wait for up to some minutes for cluster to reach HEALTH_OK
+    echo
+    echo "WWWW: ceph_health_test"
+    local minutes_to_wait="5"
+    local cluster_status=""
+    for minute in {1..$minutes_to_wait} ; do
+        set -x
+        ceph status
+        cluster_status="$(ceph health detail --format json | jq -r .status)"
+        set +x
+        if [ "$cluster_status" = "HEALTH_OK" ] ; then
+            break
+        else
+            _grace_period 60
+        fi
+    done
+    if [ "$cluster_status" != "HEALTH_OK" ] ; then
+        echo "Failed to reach HEALTH_OK even after waiting for $minutes_to_wait minutes"
+        exit 1
+    fi
+    echo "ceph_health_test: OK"
+    echo
+}
+
+function dump_ceph_bootstrap_config_test {
+    echo
+    echo "WWWW: dump_ceph_bootstrap_config_test"
+    set -x
+    ceph-bootstrap config ls /Cluster/Minions
+    ceph-bootstrap config ls /Cluster/Roles
+    ceph-bootstrap config ls /Deployment
+    ceph-bootstrap config ls /Storage
+    set +x
+    echo "dump_ceph_bootstrap_config_test: OK"
+    echo
+}
+
+function number_of_nodes_actual_vs_expected_test {
+    echo
+    echo "WWWW: number_of_nodes_actual_vs_expected_test"
+    set -x
+    local actual_total_nodes="$(json_total_nodes)"
+    local actual_mgr_nodes="$(json_total_mgrs)"
+    local actual_mon_nodes="$(json_total_mons)"
+    local actual_osd_nodes="$(json_osd_nodes)"
+    local actual_osds="$(json_total_osds)"
+    set +x
+    local all_green="yes"
+    local expected_total_nodes=""
+    local expected_mgr_nodes=""
+    local expected_mon_nodes=""
+    local expected_osd_nodes=""
+    local expected_osds=""
+    [ -z "$TOTAL_NODES" ] && expected_total_nodes="$actual_total_nodes" || expected_total_nodes="$TOTAL_NODES"
+    [ -z "$MGR_NODES" ] && expected_mgr_nodes="$actual_mgr_nodes" || expected_mgr_nodes="$MGR_NODES"
+    [ -z "$MON_NODES" ] && expected_mon_nodes="$actual_mon_nodes" || expected_mon_nodes="$MON_NODES"
+    [ -z "$OSD_NODES" ] && expected_osd_nodes="$actual_osd_nodes" || expected_osd_nodes="$OSD_NODES"
+    [ -z "$OSDS" ] && expected_osds="$actual_osds" || expected_osds="$OSDS"
+    echo "total nodes actual/expected:  $actual_total_nodes/$expected_total_nodes"
+    [ "$actual_mon_nodes" = "$expected_mon_nodes" ] || all_green=""
+    echo "MON nodes actual/expected:    $actual_mon_nodes/$expected_mon_nodes"
+    [ "$actual_mon_nodes" = "$expected_mon_nodes" ] || all_green=""
+    echo "MGR nodes actual/expected:    $actual_mgr_nodes/$expected_mgr_nodes"
+    [ "$actual_mgr_nodes" = "$expected_mgr_nodes" ] || all_green=""
+    echo "OSD nodes actual/expected:    $actual_osd_nodes/$expected_osd_nodes"
+    [ "$actual_osd_nodes" = "$expected_osd_nodes" ] || all_green=""
+    echo "total OSDs actual/expected:   $actual_osds/$expected_osds"
+    [ "$actual_osds" = "$expected_osds" ] || all_green=""
+#    echo "MDS nodes expected:     $MDS_NODES"
+#    echo "RGW nodes expected:     $RGW_NODES"
+#    echo "IGW nodes expected:     $IGW_NODES"
+#    echo "NFS-Ganesha expected:   $NFS_GANESHA_NODES"
+    if [ ! "$all_green" ] ; then
+        echo "Actual number of nodes/node types/OSDs differs from expected number"
+        exit 1
+    fi
+    echo "number_of_nodes_actual_vs_expected_test: OK"
+    echo
+}

--- a/qa/common/helper.sh
+++ b/qa/common/helper.sh
@@ -1,0 +1,41 @@
+# This file is part of the ceph-bootstrap integration test suite
+
+set -e
+
+#
+# helper functions (not to be called directly from test scripts)
+#
+
+function _ceph_cluster_running {
+    set -x
+    ceph status
+    set +x
+}
+
+function _copy_file_from_minion_to_master {
+    local MINION="$1"
+    local FULL_PATH="$2"
+    salt --static --out json "$MINION" cmd.shell "cat $FULL_PATH" | jq -r \.\"$MINION\" > $FULL_PATH
+}
+
+function _first_x_node {
+    local ROLE=$1
+    salt --static --out json -G "ceph-salt:roles:$ROLE" test.true 2>/dev/null | jq -r 'keys[0]'
+}
+
+function _grace_period {
+    local SECONDS=$1
+    echo "${SECONDS}-second grace period"
+    sleep $SECONDS
+}
+
+function _ping_minions_until_all_respond {
+    local RESPONDING=""
+    for i in {1..20} ; do
+        sleep 10
+        RESPONDING=$(salt '*' test.ping 2>/dev/null | grep True 2>/dev/null | wc --lines)
+        echo "Of $TOTAL_NODES total minions, $RESPONDING are responding"
+        test "$TOTAL_NODES" -eq "$RESPONDING" && break
+    done
+}
+

--- a/qa/common/json.sh
+++ b/qa/common/json.sh
@@ -1,0 +1,27 @@
+#
+# This file is part of the ceph-bootstrap integration test suite.
+# It contains various cluster introspection functions.
+#
+
+set -e
+
+function json_total_nodes {
+    salt --static --out json '*' test.ping 2>/dev/null | jq '. | length'
+}
+
+function json_osd_nodes {
+    ceph osd tree -f json-pretty | \
+        jq '[.nodes[] | select(.type == "host")] | length'
+}
+
+function json_total_mgrs {
+    echo "$(($(ceph status --format json | jq -r .mgrmap.num_standbys) + 1))"
+}
+
+function json_total_mons {
+    ceph status --format json | jq -r .monmap.num_mons
+}
+
+function json_total_osds {
+    ceph osd ls --format json | jq '. | length'
+}

--- a/qa/common/zypper.sh
+++ b/qa/common/zypper.sh
@@ -1,0 +1,28 @@
+# This file is part of the ceph-bootstrap integration test suite
+
+set -e
+
+#
+# zypper-specific helper functions
+#
+
+function _dump_salt_master_zypper_repos {
+    zypper lr -upEP
+}
+
+function _zypper_ref_on_master {
+    set +x
+    for delay in 60 60 60 60 ; do
+        zypper --non-interactive --gpg-auto-import-keys refresh && break
+        sleep $delay
+    done
+    set -x
+}
+
+function _zypper_install_on_master {
+    local PACKAGE=$1
+    set -x
+    zypper --non-interactive install --no-recommends "$PACKAGE"
+    set +x
+}
+

--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+#
+# ceph-bootstrap integration test automation script "health-ok.sh"
+#
+
+set -e
+trap 'catch $?' EXIT
+
+SCRIPTNAME=$(basename ${0})
+BASEDIR=$(readlink -f "$(dirname ${0})")
+test -d $BASEDIR
+#[[ $BASEDIR =~ \/ceph-bootstrap$ ]]
+
+source $BASEDIR/common/common.sh
+
+function catch {
+    echo
+    echo -n "Overall result: "
+    if [ "$1" = "0" ] ; then
+        echo "OK"
+    else
+        echo "NOT_OK (error $2)"
+    fi
+}
+
+function usage {
+    echo "$SCRIPTNAME - script for testing HEALTH_OK deployment"
+    echo "for use in SUSE Enterprise Storage testing"
+    echo
+    echo "Usage:"
+    echo "  $SCRIPTNAME [-h,--help] [--igw=X] [--mds=X] [--mgr=X]"
+    echo "  [--mon=X] [--nfs-ganesha=X] [--rgw=X]"
+    echo
+    echo "Options:"
+    echo "    --help               Display this usage message"
+    echo "    --igw-nodes          expected number of nodes with iSCSI Gateway"
+    echo "    --mds-nodes          expected number of nodes with MDS"
+    echo "    --mgr-nodes          expected number of nodes with MGR"
+    echo "    --mon-nodes          expected number of nodes with MON"
+    echo "    --nfs-ganesha-nodes  expected number of nodes with NFS-Ganesha"
+    echo "    --osd-nodes          expected number of nodes with OSD"
+    echo "    --osds               expected total number of OSDs in cluster"
+    echo "    --rgw-nodes          expected number of nodes with RGW"
+    echo
+    exit 1
+}
+
+assert_enhanced_getopt
+
+TEMP=$(getopt -o h \
+--long "help,igw-nodes:,mds-nodes:,mgr-nodes:,mon-nodes:,nfs-ganesha-nodes:,osd-nodes:,osds:,rgw-nodes:,total-nodes:" \
+-n 'health-ok.sh' -- "$@")
+
+if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
+eval set -- "$TEMP"
+
+# process command-line options
+IGW_NODES=""
+MDS_NODES=""
+MGR_NODES=""
+MON_NODES=""
+NFS_GANESHA_NODES=""
+OSD_NODES=""
+OSDS=""
+RGW_NODES=""
+TOTAL_NODES=""
+while true ; do
+    case "$1" in
+        --igw-nodes) shift ; IGW_NODES="$1" ; shift ;;
+        --mds-nodes) shift ; MDS_NODES="$1" ; shift ;;
+        --mgr-nodes) shift ; MGR_NODES="$1" ; shift ;;
+        --mon-nodes) shift ; MON_NODES="$1" ; shift ;;
+        --nfs-ganesha-nodes) shift ; NFS_GANESHA_NODES="$1" ; shift ;;
+        --osd-nodes) shift ; OSD_NODES="$1" ; shift ;;
+        --osds) shift ; OSDS="$1" ; shift ;;
+        --rgw-nodes) shift ; RGW_NODES="$1" ; shift ;;
+        --total-nodes) shift ; TOTAL_NODES="$1" ; shift ;;
+        -h|--help) usage ;;    # does not return
+        --) shift ; break ;;
+        *) echo "Internal error" ; exit 1 ;;
+    esac
+done
+
+# make Salt Master be an "admin node"
+_zypper_install_on_master ceph-common
+ADMIN_KEYRING="/etc/ceph/ceph.client.admin.keyring"
+CEPH_CONF="/etc/ceph/ceph.conf"
+mkdir -p /etc/ceph
+if [ -f "$ADMIN_KEYRING" -a -f "$CEPH_CONF" ] ; then
+    true
+else
+    set -x
+    ARBITRARY_MON_NODE="$(_first_x_node mon)"
+    if [ ! -f "$ADMIN_KEYRING" ] ; then
+        _copy_file_from_minion_to_master "$ARBITRARY_MON_NODE" "$ADMIN_KEYRING"
+        chmod 0600 "$ADMIN_KEYRING"
+    fi
+    if [ ! -f "$CEPH_CONF" ] ; then
+        _copy_file_from_minion_to_master "$ARBITRARY_MON_NODE" "$CEPH_CONF"
+    fi
+    set +x
+fi
+set -x
+test -f "$ADMIN_KEYRING"
+test -f "$CEPH_CONF"
+set +x
+
+# run tests
+ceph_version_test
+ceph_cluster_running_test
+ceph_health_test
+dump_ceph_bootstrap_config_test
+number_of_nodes_actual_vs_expected_test


### PR DESCRIPTION
The idea here is to have the ceph-bootstrap integration test code live in the same repo as ceph-bootstrap itself, and be installable on the target system (`zypper in ceph-bootstrap-qa`), and be easily runnable by both sesdev and teuthology.

Obviously, this is just a beginning. There's lots that could be added and improved, but I believe this meets the need of the hour.

NOTE: I suggest to review/try/test this PR together with https://github.com/SUSE/sesdev/pull/46