### PR TITLE
[After #39] configshell: Roles only available in advanced mode

### DIFF
--- a/ceph_bootstrap/__init__.py
+++ b/ceph_bootstrap/__init__.py
@@ -66,15 +66,17 @@ def cli(log_level, log_file):
 
 
 @cli.command(name='config')
+@click.option('-a', '--advanced', is_flag=True, default=False,
+              help='Enable all features')
 @click.argument('config_args', nargs=-1, type=click.UNPROCESSED, required=False)
-def config_shell(config_args):
+def config_shell(advanced, config_args):
     """
     Starts ceph-bootstrap configuration shell
     """
     if config_args:
-        run_config_cmdline(" ".join(config_args))
+        run_config_cmdline(advanced, " ".join(config_args))
     else:
-        run_config_shell()
+        run_config_shell(advanced)
 
 
 if __name__ == '__main__':

--- a/ceph_bootstrap/core.py
+++ b/ceph_bootstrap/core.py
@@ -41,7 +41,9 @@ class CephNode:
         self.roles.add(role)
 
     def _role_list(self):
-        return list(self.roles)
+        role_list = list(self.roles)
+        role_list.sort()
+        return role_list
 
     def _grains_value(self):
         return {
@@ -72,8 +74,9 @@ class CephNodeManager:
         PillarManager.set('ceph-salt:minions:mgr',
                           [n.short_name for n in cls._ceph_salt_nodes.values() if 'mgr' in n.roles])
 
-        # choose the the main Mon
-        minions = [n.minion_id for n in cls._ceph_salt_nodes.values() if 'mon' in n.roles]
+        # choose the the main Minion
+        minions = [n.minion_id for n in cls._ceph_salt_nodes.values()
+                   if all(r in n.roles for r in ['mon', 'mgr'])]
         minions.sort()
         if minions:  # i.e., it has at least one
             PillarManager.set('ceph-salt:bootstrap_mon', minions[0])

--- a/ceph_bootstrap/exceptions.py
+++ b/ceph_bootstrap/exceptions.py
@@ -12,3 +12,9 @@ class CephNodeFqdnResolvesToLoopbackException(CephBootstrapException):
     def __init__(self, minion_id):
         super(CephNodeFqdnResolvesToLoopbackException, self).__init__(
             "Host '{}' FQDN resolves to the loopback interface IP address".format(minion_id))
+
+
+class MinionDoesNotExistException(CephBootstrapException):
+    def __init__(self, minion_id):
+        super(MinionDoesNotExistException, self).__init__(
+            "Minion '{}' does not exist in current configuration".format(minion_id))

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -1,5 +1,5 @@
 from ceph_bootstrap.salt_utils import GrainsManager, PillarManager
-from ceph_bootstrap.config_shell import CephBootstrapConfigShell, generate_config_shell_tree
+from ceph_bootstrap.config_shell import run_config_cmdline
 
 from . import SaltMockTestCase
 
@@ -10,8 +10,6 @@ class ConfigShellTest(SaltMockTestCase):
 
     def setUp(self):
         super(ConfigShellTest, self).setUp()
-        self.shell = CephBootstrapConfigShell()
-        generate_config_shell_tree(self.shell)
 
         self.salt_env.minions = ['node1.ceph.com', 'node2.ceph.com', 'node3.ceph.com']
         GrainsManager.set_grain('node1.ceph.com', 'fqdn_ip4', ['10.20.39.201'])
@@ -19,7 +17,7 @@ class ConfigShellTest(SaltMockTestCase):
         GrainsManager.set_grain('node3.ceph.com', 'fqdn_ip4', ['10.20.39.203'])
 
     def test_cluster_minions(self):
-        self.shell.run_cmdline('/Cluster/Minions add node1.ceph.com')
+        run_config_cmdline(False, '/Cluster/Minions add node1.ceph.com')
         self.assertInSysOut('1 minion added.')
         self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True, 'roles': []})
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
@@ -27,7 +25,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {})
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_mon'), None)
 
-        self.shell.run_cmdline('/Cluster/Minions rm node1.ceph.com')
+        run_config_cmdline(False, '/Cluster/Minions rm node1.ceph.com')
         self.assertInSysOut('1 minion removed.')
         self.assertNotInGrains('node1.ceph.com', 'ceph-salt')
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), [])
@@ -35,11 +33,32 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {})
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_mon'), None)
 
+    def test_cluster_bootstrap_mon(self):
+        run_config_cmdline(False, '/Cluster/Bootstrap_Mon set node1.ceph.com')
+        self.assertInSysOut("Minion 'node1.ceph.com' does not exist in current configuration")
+
+        run_config_cmdline(False, '/Cluster/Minions add node1.ceph.com')
+        run_config_cmdline(False, '/Cluster/Bootstrap_Mon set node1.ceph.com')
+        self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True, 'roles': ['mgr', 'mon']})
+        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {'node1': '10.20.39.201'})
+        self.assertEqual(PillarManager.get('ceph-salt:bootstrap_mon'), 'node1.ceph.com')
+
+        run_config_cmdline(False, '/Cluster/Bootstrap_Mon reset')
+        self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True, 'roles': []})
+        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), [])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {})
+        self.assertEqual(PillarManager.get('ceph-salt:bootstrap_mon'), None)
+
+        run_config_cmdline(False, '/Cluster/Minions rm node1.ceph.com')
+
     def test_cluster_minions_add_invalid_ip(self):
         fqdn_ip4 = GrainsManager.get_grain('node1.ceph.com', 'fqdn_ip4')
         GrainsManager.set_grain('node1.ceph.com', 'fqdn_ip4', ['127.0.0.1'])
 
-        self.shell.run_cmdline('/Cluster/Minions add node1.ceph.com')
+        run_config_cmdline(False, '/Cluster/Minions add node1.ceph.com')
         self.assertInSysOut("Host 'node1.ceph.com' FQDN resolves to the loopback interface IP "
                             "address")
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), [])
@@ -47,23 +66,23 @@ class ConfigShellTest(SaltMockTestCase):
         GrainsManager.set_grain('node1.ceph.com', 'fqdn_ip4', fqdn_ip4)
 
     def test_cluster_minions_rm_with_role(self):
-        self.shell.run_cmdline('/Cluster/Minions add node1.ceph.com')
-        self.shell.run_cmdline('/Cluster/Roles/Mgr add node1.ceph.com')
+        run_config_cmdline(True, '/Cluster/Minions add node1.ceph.com')
+        run_config_cmdline(True, '/Cluster/Roles/Mgr add node1.ceph.com')
         self.clearSysOut()
 
-        self.shell.run_cmdline('/Cluster/Minions rm node1.ceph.com')
+        run_config_cmdline(True, '/Cluster/Minions rm node1.ceph.com')
         self.assertInSysOut("Cannot remove host 'node1.ceph.com' because it has roles defined: "
                             "{'mgr'}")
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
 
-        self.shell.run_cmdline('/Cluster/Roles/Mgr rm node1.ceph.com')
-        self.shell.run_cmdline('/Cluster/Minions rm node1.ceph.com')
+        run_config_cmdline(True, '/Cluster/Roles/Mgr rm node1.ceph.com')
+        run_config_cmdline(True, '/Cluster/Minions rm node1.ceph.com')
 
     def test_cluster_roles_mgr(self):
-        self.shell.run_cmdline('/Cluster/Minions add node1.ceph.com')
+        run_config_cmdline(True, '/Cluster/Minions add node1.ceph.com')
         self.clearSysOut()
 
-        self.shell.run_cmdline('/Cluster/Roles/Mgr add node1.ceph.com')
+        run_config_cmdline(True, '/Cluster/Roles/Mgr add node1.ceph.com')
         self.assertInSysOut('1 minion added.')
         self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True, 'roles': ['mgr']})
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
@@ -71,7 +90,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {})
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_mon'), None)
 
-        self.shell.run_cmdline('/Cluster/Roles/Mgr rm node1.ceph.com')
+        run_config_cmdline(True, '/Cluster/Roles/Mgr rm node1.ceph.com')
         self.assertInSysOut('1 minion removed.')
         self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True, 'roles': []})
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
@@ -79,131 +98,146 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {})
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_mon'), None)
 
-        self.shell.run_cmdline('/Cluster/Minions rm node1.ceph.com')
+        run_config_cmdline(False, '/Cluster/Minions rm node1.ceph.com')
 
     def test_cluster_roles_mon(self):
-        self.shell.run_cmdline('/Cluster/Minions add node1.ceph.com')
-        self.shell.run_cmdline('/Cluster/Minions add node2.ceph.com')
-        self.shell.run_cmdline('/Cluster/Roles/Mgr add node1.ceph.com')
+        run_config_cmdline(True, '/Cluster/Minions add node1.ceph.com')
+        run_config_cmdline(True, '/Cluster/Minions add node2.ceph.com')
+        run_config_cmdline(True, '/Cluster/Roles/Mgr add node1.ceph.com')
+        run_config_cmdline(True, '/Cluster/Roles/Mgr add node2.ceph.com')
         self.clearSysOut()
 
-        self.shell.run_cmdline('/Cluster/Roles/Mon add node2.ceph.com')
+        run_config_cmdline(True, '/Cluster/Roles/Mon add node2.ceph.com')
         self.assertInSysOut('1 minion added.')
-        self.assertGrains('node2.ceph.com', 'ceph-salt', {'member': True, 'roles': ['mon']})
+        self.assertGrains('node2.ceph.com', 'ceph-salt', {'member': True, 'roles': ['mgr', 'mon']})
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1', 'node2'])
-        self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), ['node1', 'node2'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {'node2': '10.20.39.202'})
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_mon'), 'node2.ceph.com')
 
-        self.shell.run_cmdline('/Cluster/Roles/Mon rm node2.ceph.com')
+        run_config_cmdline(True, '/Cluster/Roles/Mon rm node2.ceph.com')
         self.assertInSysOut('1 minion removed.')
-        self.assertGrains('node2.ceph.com', 'ceph-salt', {'member': True, 'roles': []})
+        self.assertGrains('node2.ceph.com', 'ceph-salt', {'member': True, 'roles': ['mgr']})
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1', 'node2'])
-        self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), ['node1', 'node2'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {})
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_mon'), None)
 
-        self.shell.run_cmdline('/Cluster/Roles/Mgr rm node1.ceph.com')
-        self.shell.run_cmdline('/Cluster/Minions rm node2.ceph.com')
-        self.shell.run_cmdline('/Cluster/Minions rm node1.ceph.com')
+        run_config_cmdline(True, '/Cluster/Roles/Mgr rm node2.ceph.com')
+        run_config_cmdline(True, '/Cluster/Roles/Mgr rm node1.ceph.com')
+        run_config_cmdline(True, '/Cluster/Minions rm node2.ceph.com')
+        run_config_cmdline(True, '/Cluster/Minions rm node1.ceph.com')
 
     def test_containers_images_ceph(self):
-        self.assertValueOption('/Containers/Images/ceph',
+        self.assertValueOption(False,
+                               '/Containers/Images/ceph',
                                'ceph-salt:container:images:ceph',
                                'myvalue')
 
     def test_deployment_bootstrap(self):
-        self.assertFlagOption('/Deployment/Bootstrap',
+        self.assertFlagOption(True,
+                              '/Deployment/Bootstrap',
                               'ceph-salt:deploy:bootstrap')
 
     def test_deployment_dashboard_password(self):
-        self.assertValueOption('/Deployment/Dashboard/password',
+        self.assertValueOption(True,
+                               '/Deployment/Dashboard/password',
                                'ceph-salt:dashboard:password',
                                'mypassword')
 
     def test_deployment_dashboard_username(self):
-        self.assertValueOption('/Deployment/Dashboard/username',
+        self.assertValueOption(True,
+                               '/Deployment/Dashboard/username',
                                'ceph-salt:dashboard:username',
                                'myusername')
 
     def test_deployment_mgr(self):
-        self.assertFlagOption('/Deployment/Mgr',
+        self.assertFlagOption(True,
+                              '/Deployment/Mgr',
                               'ceph-salt:deploy:mgr')
 
     def test_deployment_mon(self):
-        self.assertFlagOption('/Deployment/Mon',
+        self.assertFlagOption(True,
+                              '/Deployment/Mon',
                               'ceph-salt:deploy:mon')
 
     def test_deployment_osd(self):
-        self.assertFlagOption('/Deployment/OSD',
+        self.assertFlagOption(True,
+                              '/Deployment/OSD',
                               'ceph-salt:deploy:osd')
 
     def test_ssh(self):
-        self.shell.run_cmdline('/SSH generate')
+        run_config_cmdline(False, '/SSH generate')
         self.assertInSysOut('Key pair generated.')
         self.assertNotEqual(PillarManager.get('ceph-salt:ssh:private_key'), None)
         self.assertNotEqual(PillarManager.get('ceph-salt:ssh:public_key'), None)
 
     def test_ssh_private_key(self):
-        self.assertValueOption('/SSH/Private_Key',
+        self.assertValueOption(False,
+                               '/SSH/Private_Key',
                                'ceph-salt:ssh:private_key',
                                'myprivatekey')
 
     def test_ssh_public_key(self):
-        self.assertValueOption('/SSH/Public_Key',
+        self.assertValueOption(False,
+                               '/SSH/Public_Key',
                                'ceph-salt:ssh:public_key',
                                'mypublickey')
 
     def test_storage_drive_groups(self):
-        self.assertListOption('/Storage/Drive_Groups',
+        self.assertListOption(True,
+                              '/Storage/Drive_Groups',
                               'ceph-salt:storage:drive_groups',
                               ['value1', 'value2'])
 
     def test_time_server(self):
-        self.assertFlagOption('/Time_Server',
+        self.assertFlagOption(False,
+                              '/Time_Server',
                               'ceph-salt:time_server:enabled',
                               False)
 
     def test_time_server_external_servers(self):
-        self.assertListOption('/Time_Server/External_Servers',
+        self.assertListOption(False,
+                              '/Time_Server/External_Servers',
                               'ceph-salt:time_server:external_time_servers',
                               ['server1', 'server2'])
 
     def test_time_server_server_hostname(self):
-        self.assertValueOption('/Time_Server/Server_Hostname',
+        self.assertValueOption(False,
+                               '/Time_Server/Server_Hostname',
                                'ceph-salt:time_server:server_host',
                                'server1')
 
-    def assertFlagOption(self, path, pillar_key, reset_supported=True):
-        self.shell.run_cmdline('{} enable'.format(path))
+    def assertFlagOption(self, advanced, path, pillar_key, reset_supported=True):
+        run_config_cmdline(advanced, '{} enable'.format(path))
         self.assertInSysOut('Enabled.')
         self.assertEqual(PillarManager.get(pillar_key), True)
 
-        self.shell.run_cmdline('{} disable'.format(path))
+        run_config_cmdline(advanced, '{} disable'.format(path))
         self.assertInSysOut('Disabled.')
         self.assertEqual(PillarManager.get(pillar_key), False)
 
         if reset_supported:
-            self.shell.run_cmdline('{} reset'.format(path))
+            run_config_cmdline(advanced, '{} reset'.format(path))
             self.assertInSysOut('Value reset.')
             self.assertEqual(PillarManager.get(pillar_key), None)
 
-    def assertValueOption(self, path, pillar_key, value):
-        self.shell.run_cmdline('{} set {}'.format(path, value))
+    def assertValueOption(self, advanced, path, pillar_key, value):
+        run_config_cmdline(advanced, '{} set {}'.format(path, value))
         self.assertInSysOut('Value set.')
         self.assertEqual(PillarManager.get(pillar_key), value)
 
-        self.shell.run_cmdline('{} reset'.format(path))
+        run_config_cmdline(advanced, '{} reset'.format(path))
         self.assertInSysOut('Value reset.')
         self.assertEqual(PillarManager.get(pillar_key), None)
 
-    def assertListOption(self, path, pillar_key, values):
+    def assertListOption(self, advanced, path, pillar_key, values):
         for value in values:
-            self.shell.run_cmdline('{} add {}'.format(path, value))
+            run_config_cmdline(advanced, '{} add {}'.format(path, value))
             self.assertInSysOut('Value added.')
         self.assertEqual(PillarManager.get(pillar_key), values)
 
         for value in values:
-            self.shell.run_cmdline('{} remove {}'.format(path, value))
+            run_config_cmdline(advanced, '{} remove {}'.format(path, value))
             self.assertInSysOut('Value removed.')
         self.assertEqual(PillarManager.get(pillar_key), [])


### PR DESCRIPTION
With this PR, `Roles` (and related configs) will only be available when running in "advanced" mode.

To run `ceph-bootstrap` in advanced mode you have to specify the `-a` or `--advanced` option, e.g.:

```
ceph-bootstrap config -a
```

Fixes: https://github.com/SUSE/ceph-bootstrap/issues/28

Signed-off-by: Ricardo Marques <rimarques@suse.com>