### PR TITLE
[DNM] Support IPv6

### DIFF
--- a/ceph-salt-formula/states/cephbootstrap.sls
+++ b/ceph-salt-formula/states/cephbootstrap.sls
@@ -24,13 +24,15 @@ download ceph container image:
 
 {% set dashboard_username = pillar['ceph-salt'].get('dashboard', {'username': 'admin'}).get('username', 'admin') %}
 
+{% set short_name = grains['id'].split('.', 1)[0] %}
+
 run cephadm bootstrap:
   cmd.run:
     - name: |
 {%- if 'container' in pillar['ceph-salt'] and 'ceph' in pillar['ceph-salt']['container']['images'] %}
         CEPHADM_IMAGE={{ pillar['ceph-salt']['container']['images']['ceph'] }} \
 {%- endif %}
-        cephadm --verbose bootstrap --mon-ip {{ grains['fqdn_ip4'][0] }} \
+        cephadm --verbose bootstrap --mon-ip {{ pillar['ceph-salt']['minions']['mon'][short_name] }} \
                 --initial-dashboard-user {{ dashboard_username }} \
                 --output-keyring /etc/ceph/ceph.client.admin.keyring \
                 --output-config /etc/ceph/ceph.conf \

--- a/ceph-salt-formula/states/files/chrony.conf.j2
+++ b/ceph-salt-formula/states/files/chrony.conf.j2
@@ -7,8 +7,10 @@ pool {{ server }} iburst
 
 local stratum 10
 manual
-{% set fqdn_ip = grains['fqdn_ip4'] %}
-{% for subnet in salt['network.subnets']() %}
+{% set is_ip4 = 'ip4' == pillar['ceph-salt'].get('network', {}).get('address_family', 'ip4')%}
+{% set fqdn_ip = grains['fqdn_ip4' if is_ip4 else 'fqdn_ip6'] %}
+{% set subnets = salt['network.subnets' if is_ip4 else 'network.subnets6'] %}
+{% for subnet in subnets() %}
 {% if salt['network.ip_in_subnet'](fqdn_ip, subnet) %}
 allow {{ subnet }}
 {% endif %}

--- a/ceph_bootstrap/exceptions.py
+++ b/ceph_bootstrap/exceptions.py
@@ -12,3 +12,15 @@ class CephNodeFqdnResolvesToLoopbackException(CephBootstrapException):
     def __init__(self, minion_id):
         super(CephNodeFqdnResolvesToLoopbackException, self).__init__(
             "Host '{}' FQDN resolves to the loopback interface IP address".format(minion_id))
+
+
+class InvalidAddressFamilyException(CephBootstrapException):
+    def __init__(self, address_family):
+        super(InvalidAddressFamilyException, self).__init__(
+            "Invalid address family '{}'".format(address_family))
+
+
+class NoAddressAvailableException(CephBootstrapException):
+    def __init__(self, address_family, minion_id):
+        super(NoAddressAvailableException, self).__init__(
+            "No '{}' address available on host '{}'".format(address_family, minion_id))

--- a/ceph_bootstrap/salt_utils.py
+++ b/ceph_bootstrap/salt_utils.py
@@ -181,9 +181,13 @@ class PillarManager:
             cls.logger.debug("Loaded pillar data: %s", cls.pillar_data)
 
     @classmethod
-    def get(cls, key):
+    def get(cls, key, default=None):
         cls._load()
         res = cls._get_dict_value(cls.pillar_data, key)
+        if res is None:
+            cls.logger.info("'%s' not found in pillar, using default value '%s'", key, default)
+            return default
+
         if key == 'ceph-salt:ssh:private_key':
             # don't log key value
             cls.logger.info("Got '%s' from pillar", key)


### PR DESCRIPTION
Blocked by https://tracker.ceph.com/issues/43816
------

This PR adds support for IPv6.

Switching between `ipv4` and `ipv6` can be done using the new `/Network/Address_Family` config.

Fixes: https://github.com/SUSE/ceph-bootstrap/issues/19

Signed-off-by: Ricardo Marques <rimarques@suse.com>