### PR TITLE
Error applying "ceph-salt" state without roles

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/init.sls
@@ -7,7 +7,6 @@ include:
     - .time
 {% if pillar['ceph-salt'].get('deploy', {'bootstrap': True}).get('bootstrap', True) %}
     - .cephbootstrap
-{% endif %}
 {% if grains['id'] == pillar['ceph-salt']['bootstrap_minion'] %}
 {% if pillar['ceph-salt'].get('deploy', {'mon': False}).get('mon', False) %}
     - .ceph-mon
@@ -17,6 +16,7 @@ include:
 {% endif %}
 {% if pillar['ceph-salt'].get('deploy', {'osd': False}).get('osd', False) %}
     - .ceph-osd
+{% endif %}
 {% endif %}
 {% endif %}
 

--- a/ceph-salt-formula/salt/ceph-salt/sshkey.sls
+++ b/ceph-salt-formula/salt/ceph-salt/sshkey.sls
@@ -11,7 +11,7 @@
     - makedirs: True
     - failhard: True
 
-{% if 'mgr' in grains['ceph-salt']['roles'] or grains['id'] == pillar['ceph-salt']['bootstrap_minion'] %}
+{% if 'mgr' in grains['ceph-salt']['roles'] %}
 # private key
 /root/.ssh/id_rsa:
   file.managed:


### PR DESCRIPTION
This PR fixes errors that happen when "bootstrap_mon" or "shh" is not defined in pillar.

Fixes: https://github.com/SUSE/ceph-bootstrap/issues/45