### PR TITLE
configshell: Dashboard password must be hidden

### DIFF
--- a/ceph_bootstrap/config_shell.py
+++ b/ceph_bootstrap/config_shell.py
@@ -343,6 +343,7 @@ CEPH_BOOTSTRAP_OPTIONS = {
                     'password': {
                         'default': None,
                         'default_text': 'randomly generated',
+                        'sensitive': True,
                         'handler': PillarHandler('ceph-salt:dashboard:password')
                     },
                     'username': {
@@ -492,6 +493,8 @@ class OptionNode(configshell.ConfigNode):
             if 'handler' in self.option_dict:
                 value, val_type = self.option_dict['handler'].value()
             if value is not None:
+                if self.option_dict.get('sensitive', False):
+                    return '***', None
                 return value, val_type
             if 'default_text' in self.option_dict:
                 return self.option_dict['default_text'], None


### PR DESCRIPTION
![Screenshot from 2020-01-27 15-38-01](https://user-images.githubusercontent.com/14297426/73188653-1c1ff400-411b-11ea-9046-bc6b166487e3.png)

Fixes: https://github.com/SUSE/ceph-bootstrap/issues/48

Signed-off-by: Ricardo Marques <rimarques@suse.com>