### PR TITLE
ceph_bootstrap: Modify PyYAML prereq

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     Click >= 6.7
     configshell-fb >= 1.1
     pycryptodomex >= 3.4.6
-    PyYAML < 5.1
+    PyYAML >= 5
     salt >= 2019.2.0
 
 packages =


### PR DESCRIPTION
It's currently not possible to run ceph-bootstrap on Tumbleweed because the setup.cfg requires a version < 5.1, but 5.3 is installed on Tumbleweed.

Signed-off-by: Volker Theile <vtheile@suse.com>