### PR TITLE
ceph-salt-formula: Rename calls to Ceph Orchestrator

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/ceph-mgr.sls
+++ b/ceph-salt-formula/salt/ceph-salt/ceph-mgr.sls
@@ -13,7 +13,7 @@
 deploy remaining mgrs:
   cmd.run:
     - name: |
-        ceph orchestrator mgr update {{ mgr_update_args | join(' ') }}
+        ceph orch mgr update {{ mgr_update_args | join(' ') }}
     - failhard: True
 
 {{ macros.end_stage('Deployment of Ceph MGRs') }}

--- a/ceph-salt-formula/salt/ceph-salt/ceph-mon.sls
+++ b/ceph-salt-formula/salt/ceph-salt/ceph-mon.sls
@@ -13,7 +13,7 @@
 deploy remaining mons:
   cmd.run:
     - name: |
-        ceph orchestrator mon update {{ mon_update_args | join(' ') }}
+        ceph orch mon update {{ mon_update_args | join(' ') }}
     - failhard: True
 
 generate up-to-date ceph.conf:

--- a/ceph-salt-formula/salt/ceph-salt/ceph-osd.sls
+++ b/ceph-salt-formula/salt/ceph-salt/ceph-osd.sls
@@ -10,7 +10,7 @@
 deploy ceph osds ({{ loop.index }}/{{ dg_list | length }}):
   cmd.run:
     - name: |
-        echo '{{ dg_spec }}' | ceph orchestrator osd create -i -
+        echo '{{ dg_spec }}' | ceph orch osd create -i -
     - failhard: True
 
 {{ macros.end_step('Deploying OSD groups ' + (loop.index | string) + '/' + (dg_list | length | string)) }}

--- a/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
@@ -75,9 +75,9 @@ configure ssh orchestrator:
         ceph config-key set mgr/cephadm/ssh_identity_key -i ~/.ssh/id_rsa
         ceph config-key set mgr/cephadm/ssh_identity_pub -i ~/.ssh/id_rsa.pub
         ceph mgr module enable cephadm && \
-        ceph orchestrator set backend cephadm && \
+        ceph orch set backend cephadm && \
 {% for minion in pillar['ceph-salt']['minions']['all'] %}
-        ceph orchestrator host add {{ minion }} && \
+        ceph orch host add {{ minion }} && \
 {% endfor %}
         true
     - onchanges:


### PR DESCRIPTION
The upstream Ceph project [renamed the call](https://github.com/ceph/ceph/pull/33131) to the Ceph Orchestrator from `ceph orchestrator <command>` to `ceph orch <command>`.

Adapted the Salt formulas accordingly.

Fixes: https://github.com/SUSE/ceph-bootstrap/issues/73
Signed-off-by: Lenz Grimmer <lgrimmer@suse.com>