### PR TITLE
System update and reboot during deployment

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_orch.py
+++ b/ceph-salt-formula/salt/_modules/ceph_orch.py
@@ -1,0 +1,17 @@
+# -*- encoding: utf-8 -*-
+import json
+
+def configured():
+    ret = __salt__['cmd.run_all']("which ceph")
+    if ret['retcode'] != 0:
+        return False
+    if not __salt__['file.file_exists']("/etc/ceph/ceph.client.admin.keyring"):
+        return False
+    ret = __salt__['cmd.run_all']("ceph orch status")
+    if ret['retcode'] != 0:
+        return False
+    return True
+
+def host_ls():
+    ret = __salt__['cmd.run']("ceph orch host ls --format=json")
+    return json.loads(ret)

--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -1,0 +1,14 @@
+# -*- encoding: utf-8 -*-
+import json
+
+def get_remote_grain(host, grain):
+    ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no root@{} "
+                                  "'salt-call grains.get --out=json --out-indent=-1 {}'".format(
+                                      host, grain))
+    if ret['retcode'] != 0:
+        return None
+    return json.loads(ret['stdout'])['local']
+
+def set_remote_grain(host, grain, value):
+    return __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no root@{} "
+                                  "'salt-call grains.set {} {}'".format(host, grain, value))

--- a/ceph-salt-formula/salt/_states/ceph_salt.py
+++ b/ceph-salt-formula/salt/_states/ceph_salt.py
@@ -1,4 +1,9 @@
 # -*- encoding: utf-8 -*-
+import logging
+import time
+
+
+logger = logging.getLogger(__name__)
 
 
 def _send_event(tag, data):
@@ -25,3 +30,46 @@ def begin_step(name):
 
 def end_step(name):
     return _send_event('ceph-salt/step/end', data={'desc': name})
+
+
+def reboot_if_needed(name):
+    ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
+    needs_reboot = __salt__['cmd.run_all']('zypper ps')['retcode'] > 0
+    if needs_reboot:
+        is_master = __salt__['service.status']('salt-master')
+        if is_master:
+            ret['comment'] = 'Salt master must be rebooted manually'
+            return ret
+        __salt__['event.send']('ceph-salt/minion_reboot', data={'desc': 'Rebooting...'})
+        time.sleep(5)
+        __salt__['system.reboot']()
+    ret['result'] = True
+    return ret
+
+
+def wait_for_grain(name, grain, timeout=600):
+    ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
+    all_minions = __pillar__['ceph-salt']['minions']['all']
+    completed_counter = 0
+    starttime = time.time()
+    timelimit = starttime + timeout
+    while completed_counter < len(all_minions):
+        is_timedout = time.time() > timelimit
+        if is_timedout:
+            ret['comment'] = 'Timeout value reached.'
+            return ret
+        time.sleep(5)
+        completed_counter = 0
+        for host in all_minions:
+            grain_value = __salt__['ceph_salt.get_remote_grain'](host, 'ceph-salt:execution:failed')
+            if grain_value:
+                ret['comment'] = 'One or more minions failed.'
+                return ret
+            grain_value = __salt__['ceph_salt.get_remote_grain'](host, grain)
+            if grain_value:
+                completed_counter += 1
+        logger.info("Waiting for grain '%s' (%s/%s)", grain,
+                                                      completed_counter,
+                                                      len(all_minions))
+    ret['result'] = True
+    return ret

--- a/ceph-salt-formula/salt/ceph-salt/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephtools.sls
@@ -1,0 +1,28 @@
+{% import 'macros.yml' as macros %}
+
+{{ macros.begin_stage('Ceph tools') }}
+
+{{ macros.begin_step('Install cephadm and other packages') }}
+
+install cephadm:
+  pkg.installed:
+    - pkgs:
+        - cephadm
+{% if 'mon' in grains['ceph-salt']['roles'] %}
+        - ceph-common
+    - failhard: True
+{% endif %}
+
+{{ macros.end_step('Install cephadm and other packages') }}
+
+{{ macros.begin_step('Download ceph container image') }}
+{% if 'container' in pillar['ceph-salt'] and 'ceph' in pillar['ceph-salt']['container']['images'] %}
+download ceph container image:
+  cmd.run:
+    - name: |
+        podman pull {{ pillar['ceph-salt']['container']['images']['ceph'] }}
+    - failhard: True
+{% endif %}
+{{ macros.end_step('Download ceph container image') }}
+
+{{ macros.end_stage('Ceph tools') }}

--- a/ceph-salt-formula/salt/ceph-salt/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/init.sls
@@ -1,10 +1,13 @@
 {% if 'ceph-salt' in grains and grains['ceph-salt']['member'] %}
 
 include:
+    - .provision-begin
+    - .sshkey
     - .software
     - .apparmor
-    - .sshkey
     - .time
+    - .cephtools
+    - .provision-end
 {% if pillar['ceph-salt'].get('deploy', {'bootstrap': True}).get('bootstrap', True) %}
     - .cephbootstrap
 {% if grains['id'] == pillar['ceph-salt']['bootstrap_minion'] %}

--- a/ceph-salt-formula/salt/ceph-salt/provision-begin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/provision-begin.sls
@@ -1,0 +1,9 @@
+reset provisioned:
+  grains.present:
+    - name: ceph-salt:execution:provisioned
+    - value: False
+
+reset failure:
+  grains.present:
+    - name: ceph-salt:execution:failed
+    - value: False

--- a/ceph-salt-formula/salt/ceph-salt/provision-end.sls
+++ b/ceph-salt-formula/salt/ceph-salt/provision-end.sls
@@ -1,0 +1,4 @@
+set provisioned:
+  grains.present:
+    - name: ceph-salt:execution:provisioned
+    - value: True

--- a/ceph-salt-formula/salt/ceph-salt/software.sls
+++ b/ceph-salt-formula/salt/ceph-salt/software.sls
@@ -6,25 +6,34 @@ install required packages:
   pkg.installed:
     - pkgs:
       - iputils
+      - lsof
       - podman
     - failhard: True
 
-{% if pillar['ceph-salt'].get('upgrades', {'enabled': False})['enabled'] %}
+{% if pillar['ceph-salt'].get('updates', {}).get('enabled', True) %}
 
-{{ macros.begin_step('Upgrading all packages') }}
+{{ macros.begin_step('Updating all packages') }}
 
-upgrade packages:
+update packages:
   module.run:
     - name: pkg.upgrade
     - failhard: True
 
-{{ macros.end_step('Upgrading all packages') }}
+{{ macros.end_step('Updating all packages') }}
 
 {% else %}
 
-upgrades disabled:
+updates disabled:
   test.nop
 
 {% endif %}
 
 {{ macros.end_stage('Install and update required packages') }}
+
+{% if pillar['ceph-salt'].get('updates', {}).get('reboot', True) %}
+
+reboot:
+   ceph_salt.reboot_if_needed:
+     - failhard: True
+
+{% endif %}

--- a/ceph_bootstrap/__init__.py
+++ b/ceph_bootstrap/__init__.py
@@ -89,11 +89,12 @@ def config_shell(config_args):
 @cli.command(name='deploy')
 @click.option('-n', '--non-interactive', is_flag=True, default=False,
               help='Run deploy in non-interactive mode')
-def deploy(non_interactive):
+@click.argument('minion_id', required=False)
+def deploy(non_interactive, minion_id):
     """
     Runs ceph-salt formula and shows real-time progress
     """
-    executor = CephSaltExecutor(not non_interactive)
+    executor = CephSaltExecutor(not non_interactive, minion_id)
     retcode = executor.run()
     sys.exit(retcode)
 

--- a/ceph_bootstrap/config_shell.py
+++ b/ceph_bootstrap/config_shell.py
@@ -308,6 +308,27 @@ CEPH_BOOTSTRAP_OPTIONS = {
             },
         }
     },
+    'System_Update': {
+        'help': '''
+                System Update Options Configuration
+                =========================================
+                Options to control system updates
+                ''',
+        'options': {
+            'Packages': {
+                'type': 'flag',
+                'help': 'Update all packages',
+                'handler': PillarHandler('ceph-salt:updates:enabled'),
+                'default': True
+            },
+            'Reboot': {
+                'type': 'flag',
+                'help': 'Reboot if needed',
+                'handler': PillarHandler('ceph-salt:updates:reboot'),
+                'default': True
+            }
+        }
+    },
     'Deployment': {
         'help': '''
                 Deployment Options Configuration

--- a/ceph_bootstrap/core.py
+++ b/ceph_bootstrap/core.py
@@ -19,6 +19,7 @@ class CephNode:
         self.minion_id = minion_id
         self.short_name = minion_id.split('.', 1)[0]
         self.roles = None
+        self.execution = {}
         self.public_ip = None
         self._load()
 
@@ -33,6 +34,8 @@ class CephNode:
             self.roles = set()
         else:
             self.roles = set(result[self.minion_id]['roles'])
+        if 'execution' in result[self.minion_id]:
+            self.execution = result[self.minion_id]['execution']
 
         result = GrainsManager.get_grain(self.minion_id, 'fqdn_ip4')
         self.public_ip = result[self.minion_id][0]
@@ -48,6 +51,7 @@ class CephNode:
     def _grains_value(self):
         return {
             'member': True,
+            'execution': self.execution,
             'roles': self._role_list()
         }
 

--- a/ceph_bootstrap/exceptions.py
+++ b/ceph_bootstrap/exceptions.py
@@ -28,3 +28,9 @@ class PillarFileNotPureYaml(CephBootstrapException):
     def __init__(self, top_file_path):
         super(PillarFileNotPureYaml, self).__init__(
             "Salt pillar file '{}' may contain Jinja2 expressions".format(top_file_path))
+
+
+class MinionDoesNotExistInConfiguration(CephBootstrapException):
+    def __init__(self, minion_id):
+        super(MinionDoesNotExistInConfiguration, self).__init__(
+            "Minion '{}' does not exist in configuration".format(minion_id))

--- a/ceph_bootstrap/salt_event.py
+++ b/ceph_bootstrap/salt_event.py
@@ -7,24 +7,46 @@ import salt.config
 import salt.utils.event
 from tornado.ioloop import IOLoop
 
-
 # pylint: disable=C0103
 logger = logging.getLogger(__name__)
 
 
-class CephSaltEvent:
+class SaltEvent:
     """
-    Base class of a ceph-salt Event
+    Base class of a salt Event
     """
     def __init__(self, raw_event):
         self.raw_event = raw_event
         self.tag = raw_event['tag']
         self.minion = raw_event['data']['id']
-        self.desc = raw_event['data']['data']['desc']
         self.stamp = datetime.datetime.strptime(raw_event['data']['_stamp'], "%Y-%m-%dT%H:%M:%S.%f")
 
     def __str__(self):
-        return "[{}] [{}] [{}] {}".format(self.stamp, self.minion, self.tag, self.desc)
+        return "[{}] [{}] [{}]".format(self.stamp, self.minion, self.tag)
+
+
+class JobRetEvent(SaltEvent):
+    """
+    Base class of a job return Event
+    """
+    def __init__(self, raw_event):
+        super().__init__(raw_event)
+        self.success = raw_event['data']['success']
+
+    def __str__(self):
+        return '{} {}'.format(super().__str__(), self.success)
+
+
+class CephSaltEvent(SaltEvent):
+    """
+    Base class of a ceph-salt Event
+    """
+    def __init__(self, raw_event):
+        super().__init__(raw_event)
+        self.desc = raw_event['data']['data']['desc']
+
+    def __str__(self):
+        return '{} {}'.format(super().__str__(), self.desc)
 
 
 class EventListener:
@@ -62,17 +84,36 @@ class EventListener:
             event (CephSaltEvent): the salt event
         """
 
+    def handle_minion_reboot(self, event: CephSaltEvent):
+        """Handle minion_reboot ceph-salt event
+        Args:
+            event (CephSaltEvent): the salt event
+        """
+
+    def handle_minion_start(self, event: SaltEvent):
+        """Handle minion_start salt event
+        Args:
+            event (SaltEvent): the salt event
+        """
+
+    def handle_state_apply_return(self, event: JobRetEvent):
+        """Handle state.apply job return event
+        Args:
+            event (JobRetEvent): the salt event
+        """
+
 
 class SaltEventProcessor(threading.Thread):
     """
     This class implements an execution loop to listen for the Salt event BUS.
     """
-    def __init__(self):
+    def __init__(self, minions):
         super(SaltEventProcessor, self).__init__()
         self.running = False
         self.listeners = []
         self.io_loop = None
         self.event = threading.Event()
+        self.minions = minions
 
     def add_listener(self, listener):
         """Adds an event listener to the listener list
@@ -133,13 +174,28 @@ class SaltEventProcessor(threading.Thread):
         wrapper = None
         if fnmatch.fnmatch(event['tag'], 'ceph-salt/*'):
             wrapper = CephSaltEvent(event)
+        elif event['tag'] == 'minion_start':
+            wrapper = SaltEvent(event)
+        elif fnmatch.fnmatch(event['tag'], 'salt/job/*/ret/*'):
+            wrapper = JobRetEvent(event)
+        if wrapper:
+            if wrapper.minion not in self.minions:
+                return
             for listener in self.listeners:
-                listener.handle_ceph_salt_event(wrapper)
-                if event['tag'] == 'ceph-salt/stage/begin':
-                    listener.handle_begin_stage(wrapper)
-                elif event['tag'] == 'ceph-salt/stage/end':
-                    listener.handle_end_stage(wrapper)
-                elif event['tag'] == 'ceph-salt/step/begin':
-                    listener.handle_begin_step(wrapper)
-                elif event['tag'] == 'ceph-salt/step/end':
-                    listener.handle_end_step(wrapper)
+                if fnmatch.fnmatch(event['tag'], 'ceph-salt/*'):
+                    listener.handle_ceph_salt_event(wrapper)
+                    if event['tag'] == 'ceph-salt/stage/begin':
+                        listener.handle_begin_stage(wrapper)
+                    elif event['tag'] == 'ceph-salt/stage/end':
+                        listener.handle_end_stage(wrapper)
+                    elif event['tag'] == 'ceph-salt/step/begin':
+                        listener.handle_begin_step(wrapper)
+                    elif event['tag'] == 'ceph-salt/step/end':
+                        listener.handle_end_step(wrapper)
+                    elif event['tag'] == 'ceph-salt/minion_reboot':
+                        listener.handle_minion_reboot(wrapper)
+                elif event['tag'] == 'minion_start':
+                    listener.handle_minion_start(wrapper)
+                elif fnmatch.fnmatch(event['tag'], 'salt/job/*/ret/*'):
+                    if event['data'].get('fun') == 'state.apply':
+                        listener.handle_state_apply_return(wrapper)

--- a/ceph_bootstrap/salt_utils.py
+++ b/ceph_bootstrap/salt_utils.py
@@ -16,52 +16,34 @@ logger = logging.getLogger(__name__)
 
 
 class SaltClient:
-    _OPTS_ = None
-    _CALLER_ = None
-    _LOCAL_ = None
-    _MASTER_ = None
 
     @classmethod
     def _opts(cls, local=True):
         """
-        Initializes and retrieves the Salt opts structure
+        Retrieves the Salt opts structure
         """
-        if cls._OPTS_ is None:
-            logger.info("Initializing SaltClient with master config")
-            cls._OPTS_ = salt.config.master_config('/etc/salt/master')
-            # pylint: disable=unsupported-assignment-operation
-            if local:
-                cls._OPTS_['file_client'] = 'local'
-            logger.debug("SaltClient __opts__ = %s", cls._OPTS_)
-
-        return cls._OPTS_
+        _opts = salt.config.master_config('/etc/salt/master')
+        if local:
+            _opts['file_client'] = 'local'
+        return _opts
 
     @classmethod
     def caller(cls, local=True):
         """
-        Initializes and retrieves the Salt caller client instance
+        Retrieves a new Salt caller client instance
         """
-        if cls._CALLER_ is None:
-            cls._CALLER_ = salt.client.Caller(mopts=cls._opts(local))
-        return cls._CALLER_
+        return salt.client.Caller(mopts=cls._opts(local))
 
     @classmethod
     def local(cls):
         """
-        Initializes and retrieves the Salt local client instance
+        Retrieves a new Salt local client instance
         """
-        if cls._LOCAL_ is None:
-            cls._LOCAL_ = salt.client.LocalClient()
-        return cls._LOCAL_
+        return salt.client.LocalClient()
 
     @classmethod
     def master(cls, local=True):
-        if cls._MASTER_ is None:
-            _opts = salt.config.master_config('/etc/salt/master')
-            if local:
-                _opts['file_client'] = 'local'
-            cls._MASTER_ = salt.minion.MasterMinion(_opts)
-        return cls._MASTER_
+        return salt.minion.MasterMinion(cls._opts(local))
 
     @classmethod
     def pillar_fs_path(cls):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -124,6 +124,19 @@ class ServiceMock:
         return cls.restart_result
 
 
+class CephOrchMock:
+    configured_result = True
+    host_ls_result = []
+
+    @classmethod
+    def configured(cls):
+        return cls.configured_result
+
+    @classmethod
+    def host_ls(cls):
+        return cls.host_ls_result
+
+
 class SaltLocalClientMock:
 
     def __init__(self):
@@ -158,6 +171,8 @@ class SaltLocalClientMock:
                 result[tgt] = getattr(StateMock, func)(*args)
             elif mod == 'service':
                 result[tgt] = getattr(ServiceMock, func)(*args)
+            elif mod == 'ceph_orch':
+                result[tgt] = getattr(CephOrchMock, func)(*args)
             else:
                 raise NotImplementedError()
 

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -25,7 +25,9 @@ class ConfigShellTest(SaltMockTestCase):
     def test_cluster_minions(self):
         self.shell.run_cmdline('/Cluster/Minions add node1.ceph.com')
         self.assertInSysOut('1 minion added.')
-        self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True, 'roles': []})
+        self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True,
+                                                          'roles': [],
+                                                          'execution': {}})
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), [])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {})
@@ -69,7 +71,9 @@ class ConfigShellTest(SaltMockTestCase):
 
         self.shell.run_cmdline('/Cluster/Roles/Mgr add node1.ceph.com')
         self.assertInSysOut('1 minion added.')
-        self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True, 'roles': ['mgr']})
+        self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True,
+                                                          'roles': ['mgr'],
+                                                          'execution': {}})
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), ['node1'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {})
@@ -77,7 +81,9 @@ class ConfigShellTest(SaltMockTestCase):
 
         self.shell.run_cmdline('/Cluster/Roles/Mgr rm node1.ceph.com')
         self.assertInSysOut('1 minion removed.')
-        self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True, 'roles': []})
+        self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True,
+                                                          'roles': [],
+                                                          'execution': {}})
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), [])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {})
@@ -94,7 +100,9 @@ class ConfigShellTest(SaltMockTestCase):
 
         self.shell.run_cmdline('/Cluster/Roles/Mon add node2.ceph.com')
         self.assertInSysOut('1 minion added.')
-        self.assertGrains('node2.ceph.com', 'ceph-salt', {'member': True, 'roles': ['mgr', 'mon']})
+        self.assertGrains('node2.ceph.com', 'ceph-salt', {'member': True,
+                                                          'roles': ['mgr', 'mon'],
+                                                          'execution': {}})
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1', 'node2'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), ['node1', 'node2'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {'node2': '10.20.39.202'})
@@ -102,7 +110,9 @@ class ConfigShellTest(SaltMockTestCase):
 
         self.shell.run_cmdline('/Cluster/Roles/Mon rm node2.ceph.com')
         self.assertInSysOut('1 minion removed.')
-        self.assertGrains('node2.ceph.com', 'ceph-salt', {'member': True, 'roles': ['mgr']})
+        self.assertGrains('node2.ceph.com', 'ceph-salt', {'member': True,
+                                                          'roles': ['mgr'],
+                                                          'execution': {}})
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1', 'node2'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), ['node1', 'node2'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {})
@@ -179,6 +189,14 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertValueOption('/Time_Server/Server_Hostname',
                                'ceph-salt:time_server:server_host',
                                'server1')
+
+    def test_system_update_packages(self):
+        self.assertFlagOption('/System_Update/Packages',
+                              'ceph-salt:updates:enabled')
+
+    def test_system_update_reboot(self):
+        self.assertFlagOption('/System_Update/Reboot',
+                              'ceph-salt:updates:reboot')
 
     def assertFlagOption(self, path, pillar_key, reset_supported=True):
         self.shell.run_cmdline('{} enable'.format(path))

--- a/tests/test_grains_manager.py
+++ b/tests/test_grains_manager.py
@@ -20,8 +20,14 @@ class GrainsManagerTest(SaltMockTestCase):
         self.assertNotInGrains('test', 'key')
 
     def test_grains_filter_by(self):
-        GrainsManager.set_grain('node1', 'ceph-salt', {'member': True, 'roles': ['mon']})
-        GrainsManager.set_grain('node2', 'ceph-salt', {'member': True, 'roles': ['mgr']})
-        GrainsManager.set_grain('node3', 'ceph-salt', {'member': True, 'roles': ['storage']})
+        GrainsManager.set_grain('node1', 'ceph-salt', {'member': True,
+                                                       'roles': ['mon'],
+                                                       'execution': {}})
+        GrainsManager.set_grain('node2', 'ceph-salt', {'member': True,
+                                                       'roles': ['mgr'],
+                                                       'execution': {}})
+        GrainsManager.set_grain('node3', 'ceph-salt', {'member': True,
+                                                       'roles': ['storage'],
+                                                       'execution': {}})
         result = GrainsManager.filter_by('ceph-salt:member')
         self.assertEqual(set(result), {'node1', 'node2', 'node3'})

--- a/tests/test_salt_event.py
+++ b/tests/test_salt_event.py
@@ -5,7 +5,8 @@ from typing import List
 
 import mock
 
-from ceph_bootstrap.salt_event import SaltEventProcessor, EventListener, CephSaltEvent
+from ceph_bootstrap.salt_event import SaltEventProcessor, EventListener, CephSaltEvent, \
+    SaltEvent, JobRetEvent
 
 
 # pylint: disable=unused-argument
@@ -42,15 +43,18 @@ class SaltEventStream:
 
 
 class TestEventListener(EventListener):
-    events: List[CephSaltEvent] = []
+    ceph_salt_events: List[CephSaltEvent] = []
     begin_stage_events = []
     end_stage_events = []
     begin_step_events = []
     end_step_events = []
+    minion_reboot_events = []
+    minion_start_events = []
+    state_apply_return_events = []
 
     def handle_ceph_salt_event(self, event: CephSaltEvent):
         logger.info("received ceph-salt event: %s", event)
-        self.events.append(event)
+        self.ceph_salt_events.append(event)
 
     def handle_begin_stage(self, event: CephSaltEvent):
         self.begin_stage_events.append(event)
@@ -63,6 +67,15 @@ class TestEventListener(EventListener):
 
     def handle_end_step(self, event: CephSaltEvent):
         self.end_step_events.append(event)
+
+    def handle_minion_reboot(self, event: CephSaltEvent):
+        self.minion_reboot_events.append(event)
+
+    def handle_minion_start(self, event: SaltEvent):
+        self.minion_start_events.append(event)
+
+    def handle_state_apply_return(self, event: JobRetEvent):
+        self.state_apply_return_events.append(event)
 
 
 class TestSaltEvent(unittest.TestCase):
@@ -81,7 +94,7 @@ class TestSaltEvent(unittest.TestCase):
             patcher.start()
             self.addCleanup(patcher.stop)
 
-        self.processor = SaltEventProcessor()
+        self.processor = SaltEventProcessor(['node1.test.com', 'node2.test.com'])
         self.processor.start()
 
     def tearDown(self):
@@ -147,6 +160,14 @@ class TestSaltEvent(unittest.TestCase):
             'tag': 'ceph-salt/stage/begin',
             '_stamp': '2020-01-17T15:20:54.719389'
         })
+        SaltEventStream.push_event('ceph-salt/minion_reboot', {
+            'id': 'node2.test.com',
+            'data': {
+                'desc': 'Rebooting...'
+            },
+            'tag': 'ceph-salt/minion_reboot',
+            '_stamp': '2020-01-17T15:20:54.719389'
+        })
         SaltEventStream.flush_events()
 
         tstamp1 = datetime.datetime.strptime('2020-01-17T15:19:54.719389', "%Y-%m-%dT%H:%M:%S.%f")
@@ -154,40 +175,86 @@ class TestSaltEvent(unittest.TestCase):
         tstamp3 = datetime.datetime.strptime('2020-01-17T15:19:56.719389', "%Y-%m-%dT%H:%M:%S.%f")
         tstamp4 = datetime.datetime.strptime('2020-01-17T15:19:57.719389', "%Y-%m-%dT%H:%M:%S.%f")
         tstamp5 = datetime.datetime.strptime('2020-01-17T15:20:54.719389', "%Y-%m-%dT%H:%M:%S.%f")
+        tstamp6 = datetime.datetime.strptime('2020-01-17T15:20:54.719389', "%Y-%m-%dT%H:%M:%S.%f")
 
-        self.assertEqual(len(listener.events), 5)
+        self.assertEqual(len(listener.ceph_salt_events), 6)
         self.assertEqual(len(listener.begin_stage_events), 2)
         self.assertEqual(len(listener.end_stage_events), 1)
         self.assertEqual(len(listener.begin_step_events), 1)
         self.assertEqual(len(listener.end_step_events), 1)
+        self.assertEqual(len(listener.minion_reboot_events), 1)
 
-        self.assertEqual(listener.events[0].minion, "node1.test.com")
-        self.assertEqual(listener.events[0].desc, "Doing stuff 1")
-        self.assertEqual(listener.events[0].tag, "ceph-salt/stage/begin")
-        self.assertEqual(listener.events[0].stamp, tstamp1)
+        self.assertEqual(listener.ceph_salt_events[0].minion, "node1.test.com")
+        self.assertEqual(listener.ceph_salt_events[0].desc, "Doing stuff 1")
+        self.assertEqual(listener.ceph_salt_events[0].tag, "ceph-salt/stage/begin")
+        self.assertEqual(listener.ceph_salt_events[0].stamp, tstamp1)
 
-        self.assertEqual(listener.events[1].minion, "node1.test.com")
-        self.assertEqual(listener.events[1].desc, "Doing step 1")
-        self.assertEqual(listener.events[1].tag, "ceph-salt/step/begin")
-        self.assertEqual(listener.events[1].stamp, tstamp2)
+        self.assertEqual(listener.ceph_salt_events[1].minion, "node1.test.com")
+        self.assertEqual(listener.ceph_salt_events[1].desc, "Doing step 1")
+        self.assertEqual(listener.ceph_salt_events[1].tag, "ceph-salt/step/begin")
+        self.assertEqual(listener.ceph_salt_events[1].stamp, tstamp2)
 
-        self.assertEqual(listener.events[2].minion, "node1.test.com")
-        self.assertEqual(listener.events[2].desc, "Doing step 1")
-        self.assertEqual(listener.events[2].tag, "ceph-salt/step/end")
-        self.assertEqual(listener.events[2].stamp, tstamp3)
+        self.assertEqual(listener.ceph_salt_events[2].minion, "node1.test.com")
+        self.assertEqual(listener.ceph_salt_events[2].desc, "Doing step 1")
+        self.assertEqual(listener.ceph_salt_events[2].tag, "ceph-salt/step/end")
+        self.assertEqual(listener.ceph_salt_events[2].stamp, tstamp3)
 
-        self.assertEqual(listener.events[3].minion, "node1.test.com")
-        self.assertEqual(listener.events[3].desc, "Doing stuff 1")
-        self.assertEqual(listener.events[3].tag, "ceph-salt/stage/end")
-        self.assertEqual(listener.events[3].stamp, tstamp4)
+        self.assertEqual(listener.ceph_salt_events[3].minion, "node1.test.com")
+        self.assertEqual(listener.ceph_salt_events[3].desc, "Doing stuff 1")
+        self.assertEqual(listener.ceph_salt_events[3].tag, "ceph-salt/stage/end")
+        self.assertEqual(listener.ceph_salt_events[3].stamp, tstamp4)
 
-        self.assertEqual(listener.events[4].minion, "node2.test.com")
-        self.assertEqual(listener.events[4].desc, "Doing stuff 2")
-        self.assertEqual(listener.events[4].tag, "ceph-salt/stage/begin")
-        self.assertEqual(listener.events[4].stamp, tstamp5)
+        self.assertEqual(listener.ceph_salt_events[4].minion, "node2.test.com")
+        self.assertEqual(listener.ceph_salt_events[4].desc, "Doing stuff 2")
+        self.assertEqual(listener.ceph_salt_events[4].tag, "ceph-salt/stage/begin")
+        self.assertEqual(listener.ceph_salt_events[4].stamp, tstamp5)
 
-        self.assertEqual(listener.events[0], listener.begin_stage_events[0])
-        self.assertEqual(listener.events[1], listener.begin_step_events[0])
-        self.assertEqual(listener.events[2], listener.end_step_events[0])
-        self.assertEqual(listener.events[3], listener.end_stage_events[0])
-        self.assertEqual(listener.events[4], listener.begin_stage_events[1])
+        self.assertEqual(listener.ceph_salt_events[5].minion, "node2.test.com")
+        self.assertEqual(listener.ceph_salt_events[5].desc, "Rebooting...")
+        self.assertEqual(listener.ceph_salt_events[5].tag, "ceph-salt/minion_reboot")
+        self.assertEqual(listener.ceph_salt_events[5].stamp, tstamp6)
+
+        self.assertEqual(listener.ceph_salt_events[0], listener.begin_stage_events[0])
+        self.assertEqual(listener.ceph_salt_events[1], listener.begin_step_events[0])
+        self.assertEqual(listener.ceph_salt_events[2], listener.end_step_events[0])
+        self.assertEqual(listener.ceph_salt_events[3], listener.end_stage_events[0])
+        self.assertEqual(listener.ceph_salt_events[4], listener.begin_stage_events[1])
+        self.assertEqual(listener.ceph_salt_events[5], listener.minion_reboot_events[0])
+
+    def test_events_ignored(self):
+        listener = TestEventListener()
+        self.processor.add_listener(listener)
+
+        SaltEventStream.push_event('minion_start', {
+            'id': 'node1.test.com',
+            'tag': 'minion_start',
+            '_stamp': '2020-01-17T15:20:54.719389'
+        })
+        SaltEventStream.push_event('minion_start', {
+            'id': 'node2.test.com',
+            'tag': 'minion_start',
+            '_stamp': '2020-01-17T15:20:54.719389'
+        })
+        SaltEventStream.push_event('minion_start', {
+            'id': 'node3.test.com',
+            'tag': 'minion_start',
+            '_stamp': '2020-01-17T15:20:54.719389'
+        })
+        SaltEventStream.flush_events()
+
+        self.assertEqual(len(listener.minion_start_events), 2)
+
+    def test_state_apply_return(self):
+        listener = TestEventListener()
+        self.processor.add_listener(listener)
+
+        SaltEventStream.push_event('salt/job/20200215120107564789/ret/node1.test.com', {
+            'id': 'node1.test.com',
+            'tag': 'salt/job/20200215120107564789/ret/node1.test.com',
+            '_stamp': '2020-01-17T15:20:54.719389',
+            'fun': 'state.apply',
+            'success': True
+        })
+        SaltEventStream.flush_events()
+
+        self.assertEqual(len(listener.state_apply_return_events), 1)


### PR DESCRIPTION
With this PR it's now possible to specify if packages should be updated and if the system should be rebooted automatically when needed.

- New `/System_Updates/Packages` option
- New `/System_Updates/Reboot` option
- If `minion` is rebooted, `ceph-bootstrap deploy` will resume the execution after minion starts
- If `master` needs reboot, `ceph-bootstrap deploy` will inform the user that the reboot must be done manually
- Bootstrap minion will now wait until all minions are "provisioned"
- After the initial deployment, the "deploy" must be executed on a single minion at a time (`ceph-bootstrap deploy <minion_id>`)

Fixes: https://github.com/SUSE/ceph-bootstrap/issues/11

Signed-off-by: Ricardo Marques <rimarques@suse.com>