### PR TITLE
ceph-salt-formula: Rename ceph orch apply command

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/ceph-mgr.sls
+++ b/ceph-salt-formula/salt/ceph-salt/ceph-mgr.sls
@@ -13,7 +13,7 @@
 deploy remaining mgrs:
   cmd.run:
     - name: |
-        ceph orch mgr update {{ mgr_update_args | join(' ') }}
+        ceph orch apply mgr {{ mgr_update_args | join(' ') }}
     - failhard: True
 
 {{ macros.end_stage('Deployment of Ceph MGRs') }}

--- a/ceph-salt-formula/salt/ceph-salt/ceph-mon.sls
+++ b/ceph-salt-formula/salt/ceph-salt/ceph-mon.sls
@@ -13,7 +13,7 @@
 deploy remaining mons:
   cmd.run:
     - name: |
-        ceph orch mon update {{ mon_update_args | join(' ') }}
+        ceph orch apply mon {{ mon_update_args | join(' ') }}
     - failhard: True
 
 generate up-to-date ceph.conf:


### PR DESCRIPTION
PR https://github.com/ceph/ceph/pull/33244 renames "`ceph orch ... update`" to "`ceph orch apply ...`", so we have to adapt `ceph-bootstrap` accordingly.

Signed-off-by: Ricardo Marques <rimarques@suse.com>