### PR TITLE
ceph-salt-formula: eliminate implicit dependency on which

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_orch.py
+++ b/ceph-salt-formula/salt/_modules/ceph_orch.py
@@ -2,7 +2,7 @@
 import json
 
 def configured():
-    ret = __salt__['cmd.run_all']("which ceph")
+    ret = __salt__['cmd.run_all']("sh -c 'type ceph'")
     if ret['retcode'] != 0:
         return False
     if not __salt__['file.file_exists']("/etc/ceph/ceph.client.admin.keyring"):

--- a/ceph-salt-formula/salt/ceph-salt/apparmor.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apparmor.sls
@@ -11,7 +11,7 @@ aa-enabled:
 aa-teardown:
   cmd.run:
     - onlyif:
-      - which aa-teardown
+      - sh -c "type aa-teardown"
     - failhard: True
 
 stop apparmor:

--- a/ceph_bootstrap/deploy.py
+++ b/ceph_bootstrap/deploy.py
@@ -1235,7 +1235,7 @@ class CephSaltExecutor:
                           "the problems reported")
                 return 3
 
-        PP.println("Checking existing deployment...")
+        PP.println("Checking if there is an existing deployment...")
         result = SaltClient.local().cmd('ceph-salt:member', 'ceph_orch.configured',
                                         tgt_type='grain')
         deployed = False


### PR DESCRIPTION
"which" is not a shell builtin; it is distributed as a separate RPM.

The same functionality (testing whether a given executable is available
in the system) can be obtained using the "type" shell builtin.

Please note that this commit is not introducing a bashism:
`sh -c 'type foo'` should work regardless of which shell `/bin/sh` happens
to be pointing to.

Signed-off-by: Nathan Cutler <ncutler@suse.com>