### PR TITLE
CephSaltExecutor: check existing deployment: Use local_cmd

### DIFF
--- a/ceph_salt/deploy.py
+++ b/ceph_salt/deploy.py
@@ -1242,7 +1242,7 @@ class CephSaltExecutor:
         host_ls = []
         for minion, value in result.items():
             if value:
-                host_ls = SaltClient.local().cmd(minion, 'ceph_orch.host_ls')[minion]
+                host_ls = SaltClient.local_cmd(minion, 'ceph_orch.host_ls')[minion]
                 deployed = len(host_ls) > 0
                 break
         # day 1, but minion_id specified


### PR DESCRIPTION
`local().cmd()` doesn't properly check for errors (e.g. result is a str)

Fixes #87 

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>