### PR TITLE
Check os_family before executing zypper command

### DIFF
--- a/ceph-salt-formula/salt/_states/ceph_salt.py
+++ b/ceph-salt-formula/salt/_states/ceph_salt.py
@@ -34,7 +34,11 @@ def end_step(name):
 
 def reboot_if_needed(name):
     ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
-    needs_reboot = __salt__['cmd.run_all']('zypper ps')['retcode'] > 0
+    if __grains__.get('os_family') == 'Suse':
+        needs_reboot = __salt__['cmd.run_all']('zypper ps')['retcode'] > 0
+    else:
+        ret['comment'] = 'Unsupported distribution: Unable to check if reboot is needed'
+        return ret
     if needs_reboot:
         is_master = __salt__['service.status']('salt-master')
         if is_master:


### PR DESCRIPTION
This PR will check if SUSE distro is being used before executing `zypper ps` command, otherwise an error will be shown.

Support for other distros will be tracked on https://github.com/SUSE/ceph-bootstrap/issues/91

Signed-off-by: Ricardo Marques <rimarques@suse.com>