### PR TITLE
Fix salt job return event processing

### DIFF
--- a/ceph_salt/salt_event.py
+++ b/ceph_salt/salt_event.py
@@ -177,7 +177,8 @@ class SaltEventProcessor(threading.Thread):
         elif event['tag'] == 'minion_start':
             wrapper = SaltEvent(event)
         elif fnmatch.fnmatch(event['tag'], 'salt/job/*/ret/*'):
-            wrapper = JobRetEvent(event)
+            if event['data'].get('fun') == 'state.apply':
+                wrapper = JobRetEvent(event)
         if wrapper:
             if wrapper.minion not in self.minions:
                 return


### PR DESCRIPTION
The only salt job return event that is used by `ceph-salt` is the `state.apply`, so we can ignore others.

This PR fixes the following error:

```
===
2020-02-21 14:47:35,616 [ERROR] [tornado.application] Exception in callback functools.partial(<function wrap.<locals>.null_wrapper at 0x7f581ce6e488>, b'salt/job/202002211447
35608543/ret/osd-node4.openstack.local\n\n\x8b\xa3cmd\xa7_return\xa2id\xb9osd-node4.openstack.local\xa3jid\xb420200221144735608543\xa6return\xc3\xa7retcode\x00\xa3fun\xaagrai
ns.get\xa8fun_args\x91\xbfceph-salt:execution:provisioned\xa3arg\x91\xbfceph-salt:execution:provisioned\xa8tgt_type\xa4glob\xa3tgt\xb9osd-node4.openstack.local\xa6_stamp\xba2
020-02-21T14:47:35.612813')
Traceback (most recent call last):
  File "/usr/lib64/python3.6/site-packages/tornado/ioloop.py", line 604, in _run_callback
    ret = callback()
  File "/usr/lib64/python3.6/site-packages/tornado/stack_context.py", line 276, in null_wrapper
    return fn(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/ceph_bootstrap/salt_event.py", line 163, in _handle_event_recv
    self._process({'tag': mtag, 'data': data})
  File "/usr/lib/python3.6/site-packages/ceph_bootstrap/salt_event.py", line 180, in _process
    wrapper = JobRetEvent(event)
  File "/usr/lib/python3.6/site-packages/ceph_bootstrap/salt_event.py", line 34, in __init__
    self.success = raw_event['data']['success']
KeyError: 'success'
===
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>