### PR TITLE
salt formula: add `--skip-prepare-host` to `cephadm bootstrap`

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
@@ -32,6 +32,7 @@ run cephadm bootstrap:
                 --initial-dashboard-user {{ dashboard_username }} \
                 --output-keyring /etc/ceph/ceph.client.admin.keyring \
                 --output-config /etc/ceph/ceph.conf \
+                --skip-prepare-host
                 --skip-ssh > /var/log/ceph/cephadm.log 2>&1
     - creates:
       - /etc/ceph/ceph.conf

--- a/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
@@ -32,7 +32,7 @@ run cephadm bootstrap:
                 --initial-dashboard-user {{ dashboard_username }} \
                 --output-keyring /etc/ceph/ceph.client.admin.keyring \
                 --output-config /etc/ceph/ceph.conf \
-                --skip-prepare-host
+                --skip-prepare-host \
                 --skip-ssh > /var/log/ceph/cephadm.log 2>&1
     - creates:
       - /etc/ceph/ceph.conf


### PR DESCRIPTION
Adding `skip-prepare-host` will prevent any potential conflicts
when ceph-salt and cephadm prepare-host will do things.

Depends on https://github.com/ceph/ceph/pull/33504

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>