### PR TITLE
ceph-osd: work around osd deployment "false positive"

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/ceph-osd.sls
+++ b/ceph-salt-formula/salt/ceph-salt/ceph-osd.sls
@@ -2,6 +2,16 @@
 
 {{ macros.begin_stage('Deployment of Ceph OSDs') }}
 
+{{ macros.begin_step('Spinning wheels for 60 seconds to work around https://tracker.ceph.com/issues/44270') }}
+
+spin wheels for 60 seconds before creating any osds:
+  cmd.run:
+    - name: |
+        sleep 60
+    - failhard: True
+
+{{ macros.end_step('Spinning wheels for 60 seconds to work around https://tracker.ceph.com/issues/44270') }}
+
 {% set dg_list = pillar['ceph-salt'].get('storage', {'drive_groups': []}).get('drive_groups', []) %}
 {% for dg_spec in dg_list %}
 


### PR DESCRIPTION
Due to an upstream issue in the Orchestrator, OSD deployment succeeds
without actually deploying any OSDs. Add a "sleep" to work around this
and enable OSD deployment to succeed.

Works-Around: https://tracker.ceph.com/issues/44270
Signed-off-by: Nathan Cutler <ncutler@suse.com>