### PR TITLE
ceph-osd: work around timing issue in device list

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/ceph-osd.sls
+++ b/ceph-salt-formula/salt/ceph-salt/ceph-osd.sls
@@ -10,6 +10,7 @@
 deploy ceph osds ({{ loop.index }}/{{ dg_list | length }}):
   cmd.run:
     - name: |
+        ceph orch device ls --refresh
         echo '{{ dg_spec }}' | ceph orch osd create -i -
     - failhard: True
 


### PR DESCRIPTION
References: https://bugzilla.suse.com/show_bug.cgi?id=1165491 (non-public - bug description follows!)

This bug appears to be reproducible with the M6 candidate ceph 15.1.0-1521-gcdf35413a0 

A standard 4-node cluster is deployed using the command:

`sesdev create ses7 --ceph-salt-repo https://github.com/ceph/ceph-salt.git --ceph-salt-branch master --ceph-container-image="registry.suse.de/devel/storage/7.0/containers/ses/7/ceph/ceph" ses7_test1`

During deployment via ceph-salt it is observed that three OSD groups are (supposedly) deployed - one for each of the three OSD nodes. But only the first OSD group is actually deployed. Deployment of Groups 2 and 3 goes really fast and does not result in any OSDs being deployed. The resulting cluster has only two OSDs, instead of the expected six.

Upon closer examination, we can see that the following commands succeed without causing any OSDs to be deployed:

`echo {\"testing_dg_node2\": {\"host_pattern\": \"node2*\", \"data_devices\": {\"all\": true}}} | ceph orch osd create -i -`

This is because the orchestrator only knows about the drives on node1:

```
admin:~ # ceph orch device ls
HOST   PATH      TYPE   SIZE  DEVICE  AVAIL  REJECT REASONS  
node1  /dev/vdb  hdd   8192M  259451  True                   
node1  /dev/vdc  hdd   8192M  652460  True                   
node1  /dev/vda  hdd   42.0G          False  locked 
```

Yet "cephadm ceph-volume inventory" sees the drives when run on node2:

```
node2:~ # cephadm ceph-volume inventory
INFO:cephadm:Inferring fsid a581fad8-5ccb-11ea-966f-525400bb7fa5
INFO:cephadm:/usr/bin/podman:stdout 
INFO:cephadm:/usr/bin/podman:stdout Device Path               Size         rotates available Model name
INFO:cephadm:/usr/bin/podman:stdout /dev/vdb                  8.00 GB      True    True      
INFO:cephadm:/usr/bin/podman:stdout /dev/vdc                  8.00 GB      True    True      
INFO:cephadm:/usr/bin/podman:stdout /dev/vda                  42.00 GB     True    False     

Device Path               Size         rotates available Model name
/dev/vdb                  8.00 GB      True    True      
/dev/vdc                  8.00 GB      True    True      
/dev/vda                  42.00 GB     True    False
```