### PR TITLE
Renamed "host" field to "hostname"

### DIFF
--- a/ceph_salt/deploy.py
+++ b/ceph_salt/deploy.py
@@ -1261,7 +1261,7 @@ class CephSaltExecutor:
         if deployed and minion_id is not None:
             minion_short_name = minion_id.split('.', 1)[0]
             for host in host_ls:
-                if minion_short_name == host['host']:
+                if minion_short_name == host['hostname']:
                     logger.error("minion_id already deployed: %s", minion_id)
                     PP.pl_red("Minion '{}' is already deployed".format(minion_id))
                     return 6

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -336,14 +336,14 @@ class DeployTest(SaltMockTestCase):
 
     def test_check_deploy_prerequesites_day2_without_minion(self):
         self.fs.create_file(os.path.join(self.states_fs_path(), 'ceph-salt.sls'))
-        CephOrchMock.host_ls_result = [{'host': 'node1.test.com'}]
+        CephOrchMock.host_ls_result = [{'hostname': 'node1.test.com'}]
         self.assertEqual(CephSaltExecutor.check_deploy_prerequesites(None), 5)
         CephOrchMock.host_ls_result = []
         self.fs.remove_object(os.path.join(self.states_fs_path(), 'ceph-salt.sls'))
 
     def test_check_deploy_prerequesites_day2_with_minion_deployed(self):
         self.fs.create_file(os.path.join(self.states_fs_path(), 'ceph-salt.sls'))
-        CephOrchMock.host_ls_result = [{'host': 'node1'}]
+        CephOrchMock.host_ls_result = [{'hostname': 'node1'}]
         self.assertEqual(CephSaltExecutor.check_deploy_prerequesites('node1.test.com'), 6)
         CephOrchMock.host_ls_result = []
         self.fs.remove_object(os.path.join(self.states_fs_path(), 'ceph-salt.sls'))


### PR DESCRIPTION
`ceph orch host ls --format=json` has renamed "host" field to "hostname", causing the following error in `ceph-salt`:

```
admin:~ # ceph-salt deploy node3.octopus.com
Checking if ceph-salt formula is available...
Syncing minions with the master...
Checking if there is an existing deployment...
Traceback (most recent call last):
  File "/usr/bin/ceph-salt", line 11, in <module>
    load_entry_point('ceph-salt==15.1.0+1583164799.g42f8dbf', 'console_scripts', 'ceph-salt')()
  File "/usr/lib/python3.6/site-packages/ceph_salt/__init__.py", line 55, in ceph_salt_main
    cli(prog_name='ceph-salt')
  File "/usr/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/ceph_salt/__init__.py", line 98, in deploy
    retcode = executor.run()
  File "/usr/lib/python3.6/site-packages/ceph_salt/deploy.py", line 1272, in run
    retcode = self.check_deploy_prerequesites(self.minion_id)
  File "/usr/lib/python3.6/site-packages/ceph_salt/deploy.py", line 1264, in check_deploy_prerequesites
    if minion_short_name == host['host']:
KeyError: 'host'
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>