### PR TITLE
Allow users to configure custom registries

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/container.sls
+++ b/ceph-salt-formula/salt/ceph-salt/container.sls
@@ -1,0 +1,20 @@
+{% import 'macros.yml' as macros %}
+
+{{ macros.begin_stage('Container environment') }}
+
+{{ macros.begin_step('Configure registries') }}
+
+/etc/containers/registries.conf:
+  file.managed:
+    - source:
+        - salt://ceph-salt/files/registries.conf.j2
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: '0644'
+    - backup: minion
+    - failhard: True
+
+{{ macros.end_step('Configure registries') }}
+
+{{ macros.end_stage('Container environment') }}

--- a/ceph-salt-formula/salt/ceph-salt/files/chrony.conf.j2
+++ b/ceph-salt-formula/salt/ceph-salt/files/chrony.conf.j2
@@ -1,3 +1,4 @@
+# {% include "ceph-salt/files/managed-header.txt.j2" ignore missing %}
 {%- set time_server = pillar['ceph-salt']['time_server']['server_host'] %}
 {%- if grains['fqdn'] == time_server %}
 {%- for server in pillar['ceph-salt']['time_server'].get('external_time_servers', []) %}

--- a/ceph-salt-formula/salt/ceph-salt/files/managed-header.txt.j2
+++ b/ceph-salt-formula/salt/ceph-salt/files/managed-header.txt.j2
@@ -1,0 +1,1 @@
+This file is managed by ceph-salt.

--- a/ceph-salt-formula/salt/ceph-salt/files/registries.conf.j2
+++ b/ceph-salt-formula/salt/ceph-salt/files/registries.conf.j2
@@ -1,0 +1,20 @@
+{% set registries = pillar['ceph-salt'].get('container', {}).get('registries', []) -%}
+# {% include "ceph-salt/files/managed-header.txt.j2" ignore missing %}
+# For more information on this configuration file, see containers-registries.conf(5)
+
+# An array of host[:port] registries to try when pulling an unqualified image, in order
+unqualified-search-registries = ["docker.io"]
+
+{% for reg in registries %}
+[[registry]]
+{% if reg.prefix is defined %}
+prefix = "{{ reg.prefix }}"
+{% endif %}
+location = "{{ reg.location }}"
+{% if reg.insecure is defined %}
+insecure = {{ '{}'.format(reg.insecure) | lower }}
+{% endif %}
+{% if reg.blocked is defined %}
+blocked = {{ '{}'.format(reg.blocked) | lower }}
+{% endif %}
+{% endfor %}

--- a/ceph-salt-formula/salt/ceph-salt/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/init.sls
@@ -4,6 +4,7 @@ include:
     - .provision-begin
     - .sshkey
     - .software
+    - .container
     - .apparmor
     - .time
     - .cephtools

--- a/ceph_salt/exceptions.py
+++ b/ceph_salt/exceptions.py
@@ -28,3 +28,7 @@ class MinionDoesNotExistInConfiguration(CephSaltException):
     def __init__(self, minion_id):
         super(MinionDoesNotExistInConfiguration, self).__init__(
             "Minion '{}' does not exist in configuration".format(minion_id))
+
+
+class ParamsException(CephSaltException):
+    pass

--- a/ceph_salt/params_helper.py
+++ b/ceph_salt/params_helper.py
@@ -1,0 +1,24 @@
+class Validator():
+    @classmethod
+    def validate(cls, value):
+        raise NotImplementedError()
+
+
+class Transformer():
+    @classmethod
+    def transform(cls, value):
+        raise NotImplementedError()
+
+
+class BooleanStringValidator(Validator):
+    """Validate a string is in boolean type."""
+    @classmethod
+    def validate(cls, value):
+        return value.lower() in ['true', 'false', '1', '0']
+
+
+class BooleanStringTransformer(Transformer):
+    """Transform a boolean string to boolean type."""
+    @classmethod
+    def transform(cls, value):
+        return value.lower() in ['true', '1']

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -296,3 +296,14 @@ class ConfigShellTest(SaltMockTestCase):
             self.shell.run_cmdline('{} remove {}'.format(path, value))
             self.assertInSysOut('Value removed.')
         self.assertEqual(PillarManager.get(pillar_key), [])
+
+    def assertListDictOption(self, path, pillar_key, values, check_values):
+        for value in values:
+            self.shell.run_cmdline('{} add {}'.format(path, value))
+            self.assertInSysOut('Value added.')
+        self.assertEqual(PillarManager.get(pillar_key), check_values)
+
+        for value in values:
+            self.shell.run_cmdline('{} remove {}'.format(path, value))
+            self.assertInSysOut('Value removed.')
+        self.assertEqual(PillarManager.get(pillar_key), [])

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -115,6 +115,24 @@ class ConfigShellTest(SaltMockTestCase):
                                'ceph-salt:container:images:ceph',
                                'myvalue')
 
+    def test_containers_registries(self):
+        self.assertListDictOption('/containers/registries',
+                                  'ceph-salt:container:registries',
+                                  ['location=172.17.0.1:5000 insecure=false',
+                                   ('location=192.168.0.1:8080/docker.io prefix=docker.io'
+                                    ' insecure=1')],
+                                  [
+                                      {
+                                          'location': '172.17.0.1:5000',
+                                          'insecure': False
+                                      },
+                                      {
+                                          'location': '192.168.0.1:8080/docker.io',
+                                          'prefix': 'docker.io',
+                                          'insecure': True
+                                      }
+                                  ])
+
     def test_cephadm_bootstrap(self):
         self.assertFlagOption('/cephadm_bootstrap',
                               'ceph-salt:bootstrap_enabled')
@@ -300,10 +318,10 @@ class ConfigShellTest(SaltMockTestCase):
     def assertListDictOption(self, path, pillar_key, values, check_values):
         for value in values:
             self.shell.run_cmdline('{} add {}'.format(path, value))
-            self.assertInSysOut('Value added.')
+            self.assertInSysOut('Item added.')
         self.assertEqual(PillarManager.get(pillar_key), check_values)
 
         for value in values:
             self.shell.run_cmdline('{} remove {}'.format(path, value))
-            self.assertInSysOut('Value removed.')
+            self.assertInSysOut('item(s) removed.')
         self.assertEqual(PillarManager.get(pillar_key), [])


### PR DESCRIPTION
**Update**: Now supports V2 registry config.

User can configure custom registries as cache of public registries or
pull images from insecure registries.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

## About V2 registry config

V2 config allows configuring image pulling behaviors related to registries :
- Specify alternative location of an image.
  Say users want to do an air-gap deployment, but the image `docker.io/ceph/daemon-base:latest-master-devel` is not reachable from the local LAN. User can mirror the image to a local registry:
  ```
  # using skopeo as an example, in practice user might need to load a tarball
  # skopeo copy --dest-tls-verify=false docker://docker.io/ceph/daemon-base:latest-master-devel docker://192.168.2.106:5000/docker.io/ceph/daemon-base:latest-master-devel
  ```
  
  User then specify the local registry as an alternative location in the config:
  ```
  # cat /etc/containers/registries.conf
  [[registry]]
  prefix = "docker.io"
  location = "192.168.2.106:5000/docker.io"
  insecure = true
  ```
  
  The User then pull the image as usual, but because the config exists, it will directly pull the image from `192.168.2.106:5000/docker.io/ceph/daemon-base:latest-master-devel`:
  ```
  # podman pull docker.io/ceph/daemon-base:latest-master-devel  
  ```

- Use an insecure local registry.
  With the following config:
  ```
  [[registry]]
  location = "192.168.2.106:5000"
  insecure = true
  ```
  
  Users can pull images from `192.168.2.106:5000` even it's not SSL-enabled.

## How to test

Use sesdev to prepare an env and stop before deploy.

### [Bring up a docker registry](https://docs.docker.com/registry/#basic-commands) and push an image into it.
e.g. sync latest octopus image to 192.168.2.106:5000
```
skopeo copy --dest-tls-verify=false docker://registry.opensuse.org/filesystems/ceph/master/upstream/images/ceph/ceph docker://192.168.2.106:5000/registry.opensuse.org/filesystems/ceph/master/upstream/images/ceph/ceph
```

### Add registries to pillar:

```
ceph-salt config /containers/registries add prefix=registry.opensuse.org location=192.168.2.106:5000/registry.opensuse.org insecure=true
```

### Specify an image from the insecure registry

This step can be skipped. Because by default we already use `registry.opensuse.org/filesystems/ceph/master/upstream/images/ceph/ceph` as image path. And because we configured the registries config, podman will pulls image from `172.17.0.1:5000/registry.opensuse.org`.

```
ceph-salt config /containers/images/ceph set registry.opensuse.org/filesystems/ceph/master/upstream/images/ceph/ceph
```

### Deploy
```
ceph-salt -ldebug deploy --non-interactive
```

## The example config after states are applied

```
master:/srv/salt # cat /etc/containers/registries.conf 
# This file is managed by ceph-salt.
# For more information on this configuration file, see containers-registries.conf(5)

# An array of host[:port] registries to try when pulling an unqualified image, in order
unqualified-search-registries = ["docker.io"]

[[registry]]

prefix = "quay.io"

location = "192.168.2.106:5000/quay.io"

insecure = true

```


