### PR TITLE
spec,setup.cfg: bump PyYAML dependency

### DIFF
--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -44,7 +44,7 @@ BuildRequires:  python3-setuptools
 Requires:       python3-click >= 6.7
 Requires:       python3-configshell-fb >= 1.1
 Requires:       python3-pycryptodomex >= 3.4.6
-Requires:       python3-PyYAML >= 3.13
+Requires:       python3-PyYAML >= 5.1.2
 Requires:       python3-setuptools
 Requires:       python3-salt >= 2019.2.0
 Requires:       python3-curses

--- a/ceph_salt/salt_utils.py
+++ b/ceph_salt/salt_utils.py
@@ -228,7 +228,7 @@ class PillarManager:
             return {}
         with open(full_path, 'r') as file:
             try:
-                data = yaml.load(file)
+                data = yaml.full_load(file)
                 if data is None:
                     data = {}
             except yaml.error.YAMLError:

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     Click >= 6.7
     configshell-fb >= 1.1
     pycryptodomex >= 3.4.6
-    PyYAML < 5.1
+    PyYAML >= 5.1.2
     salt < 3000
 
 packages =

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -295,5 +295,5 @@ class SaltMockTestCase(TestCase):
     def assertYamlEqual(self, file_path, _dict):
         data = None
         with open(file_path, 'r') as file:
-            data = yaml.load(file)
+            data = yaml.full_load(file)
         self.assertDictEqual(data, _dict)


### PR DESCRIPTION
openSUSE Leap 15.[12] now ships python3-PyYAML version 5.1.2, which
makes it difficult to install ceph-salt from source:

admin:~/ceph-salt # pip install .
Processing /root/ceph-salt
Requirement already satisfied: Click>=6.7 in /usr/lib/python3.6/site-packages (from ceph-salt==15.1.0) (7.0)
Requirement already satisfied: configshell-fb>=1.1 in /usr/lib/python3.6/site-packages (from ceph-salt==15.1.0) (1.1.27)
Requirement already satisfied: pycryptodomex>=3.4.6 in /usr/lib64/python3.6/site-packages (from ceph-salt==15.1.0) (3.9.7)
Collecting PyYAML<5.1 (from ceph-salt==15.1.0)
  Using cached https://files.pythonhosted.org/packages/9e/a3/1d13970c3f36777c583f136c136f804d70f500168edc1edea6daa7200769/PyYAML-3.13.tar.gz
Requirement already satisfied: salt<3000 in /usr/lib/python3.6/site-packages (from ceph-salt==15.1.0) (2019.2.3)
Requirement already satisfied: pyparsing>=2.0.2 in /usr/lib/python3.6/site-packages (from configshell-fb>=1.1->ceph-salt==15.1.0) (2.2.0)
Requirement already satisfied: six in /usr/lib/python3.6/site-packages (from configshell-fb>=1.1->ceph-salt==15.1.0) (1.11.0)
Requirement already satisfied: urwid in /usr/lib64/python3.6/site-packages (from configshell-fb>=1.1->ceph-salt==15.1.0) (2.1.0)
Installing collected packages: PyYAML, ceph-salt
  Found existing installation: PyYAML 5.1.2
Cannot uninstall 'PyYAML'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.

Signed-off-by: Nathan Cutler <ncutler@suse.com>