### PR TITLE
Fix error when deploying additional mgrs

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/ceph-mgr.sls
+++ b/ceph-salt-formula/salt/ceph-salt/ceph-mgr.sls
@@ -13,7 +13,7 @@
 deploy remaining mgrs:
   cmd.run:
     - name: |
-        ceph orch apply mgr {{ mgr_update_args | length }} {{ mgr_update_args | join(' ') }}
+        ceph orch apply mgr {{ mgr_update_args | join(',') }}
     - failhard: True
 
 {{ macros.end_stage('Deployment of Ceph MGRs') }}


### PR DESCRIPTION
mgr deployment fails because of PlacementSpec change in
https://github.com/ceph/ceph/pull/33706.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>