### PR TITLE
Add "Admin" role

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/ceph-admin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/ceph-admin.sls
@@ -1,0 +1,20 @@
+{% import 'macros.yml' as macros %}
+
+{% if pillar['ceph-salt']['minions']['admin'] | length > 1 %}
+
+{{ macros.begin_stage('Copying ceph.conf and keyring to other Admin nodes') }}
+
+copy ceph.conf and keyring to other admin nodes:
+  cmd.run:
+    - name: |
+{%- for minion in pillar['ceph-salt']['minions']['admin'] %}
+{%- if minion != grains['host'] %}
+        scp -o "StrictHostKeyChecking=no" /etc/ceph/ceph.conf root@{{ minion }}:/etc/ceph/
+        scp -o "StrictHostKeyChecking=no" /etc/ceph/ceph.client.admin.keyring root@{{ minion }}:/etc/ceph/
+{%- endif %}
+{%- endfor %}
+    - failhard: True
+
+{{ macros.end_stage('Copying ceph.conf and keyring to other Admin nodes') }}
+
+{% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/ceph-mon.sls
+++ b/ceph-salt-formula/salt/ceph-salt/ceph-mon.sls
@@ -20,24 +20,6 @@ deploy remaining mon {{ add_mon_arg }}:
 
 {% endfor %}
 
-generate up-to-date ceph.conf:
-  cmd.run:
-    - name: |
-        ceph config generate-minimal-conf > /tmp/ceph.conf
-        mv /tmp/ceph.conf /etc/ceph/
-    - failhard: True
-
-copy ceph.conf and keyring to other mons:
-  cmd.run:
-    - name: |
-{%- for minion, ip in pillar['ceph-salt']['minions']['mon'].items() %}
-{%- if minion != grains['id'] %}
-        scp -o "StrictHostKeyChecking=no" /etc/ceph/ceph.conf root@{{ ip }}:/etc/ceph/
-        scp -o "StrictHostKeyChecking=no" /etc/ceph/ceph.client.admin.keyring root@{{ ip }}:/etc/ceph/
-{%- endif %}
-{%- endfor %}
-    - failhard: True
-
 {{ macros.end_stage('Deployment of Ceph MONs') }}
 
 {% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephtools.sls
@@ -8,7 +8,7 @@ install cephadm:
   pkg.installed:
     - pkgs:
         - cephadm
-{% if 'mon' in grains['ceph-salt']['roles'] %}
+{% if 'admin' in grains['ceph-salt']['roles'] %}
         - ceph-common
     - failhard: True
 {% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/init.sls
@@ -11,6 +11,7 @@ include:
 {% if pillar['ceph-salt'].get('deploy', {'bootstrap': True}).get('bootstrap', True) %}
     - .cephbootstrap
 {% if grains['id'] == pillar['ceph-salt']['bootstrap_minion'] %}
+    - .ceph-admin
 {% if pillar['ceph-salt'].get('deploy', {'mon': False}).get('mon', False) %}
     - .ceph-mon
 {% endif %}

--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -273,6 +273,12 @@ CEPH_SALT_OPTIONS = {
                         ====================================
                         ''',
                 'options': {
+                    'Admin': {
+                        'type': 'minions',
+                        'default': [],
+                        'handler': RoleHandler('admin'),
+                        'help': 'List of minions with Admin role'
+                    },
                     'Mon': {
                         'type': 'minions',
                         'default': [],

--- a/ceph_salt/core.py
+++ b/ceph_salt/core.py
@@ -77,6 +77,9 @@ class CephNodeManager:
                            if 'mon' in n.roles})
         PillarManager.set('ceph-salt:minions:mgr',
                           [n.short_name for n in cls._ceph_salt_nodes.values() if 'mgr' in n.roles])
+        PillarManager.set('ceph-salt:minions:admin',
+                          [n.short_name for n in cls._ceph_salt_nodes.values()
+                           if 'admin' in n.roles])
 
         # choose the the main Mon
         minions = [n.minion_id for n in cls._ceph_salt_nodes.values()

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -8,6 +8,10 @@ def validate_config():
     bootstrap_minion = PillarManager.get('ceph-salt:bootstrap_minion')
     if not bootstrap_minion:
         return "At least one minion must be both 'Mgr' and 'Mon'"
+    bootstrap_minion_short_name = bootstrap_minion.split('.', 1)[0]
+    admin_nodes = PillarManager.get('ceph-salt:minions:admin')
+    if bootstrap_minion_short_name not in admin_nodes:
+        return "Bootstrap minion must be 'Admin'"
     ceph_container_image_path = PillarManager.get('ceph-salt:container:images:ceph')
     if not ceph_container_image_path:
         return "No Ceph container image path specified in config"

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -68,6 +68,34 @@ class ConfigShellTest(SaltMockTestCase):
         self.shell.run_cmdline('/Cluster/Roles/Mgr rm node1.ceph.com')
         self.shell.run_cmdline('/Cluster/Minions rm node1.ceph.com')
 
+    def test_cluster_roles_admin(self):
+        self.shell.run_cmdline('/Cluster/Minions add node1.ceph.com')
+        self.clearSysOut()
+
+        self.shell.run_cmdline('/Cluster/Roles/Admin add node1.ceph.com')
+        self.assertInSysOut('1 minion added.')
+        self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True,
+                                                          'roles': ['admin'],
+                                                          'execution': {}})
+        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), [])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {})
+        self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
+
+        self.shell.run_cmdline('/Cluster/Roles/Admin rm node1.ceph.com')
+        self.assertInSysOut('1 minion removed.')
+        self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True,
+                                                          'roles': [],
+                                                          'execution': {}})
+        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), [])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {})
+        self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
+
+        self.shell.run_cmdline('/Cluster/Minions rm node1.ceph.com')
+
     def test_cluster_roles_mgr(self):
         self.shell.run_cmdline('/Cluster/Minions add node1.ceph.com')
         self.clearSysOut()
@@ -78,6 +106,7 @@ class ConfigShellTest(SaltMockTestCase):
                                                           'roles': ['mgr'],
                                                           'execution': {}})
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), ['node1'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {})
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
@@ -88,6 +117,7 @@ class ConfigShellTest(SaltMockTestCase):
                                                           'roles': [],
                                                           'execution': {}})
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), [])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {})
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
@@ -108,6 +138,7 @@ class ConfigShellTest(SaltMockTestCase):
                                         'roles': ['mgr', 'mon'],
                                         'execution': {}})
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1', 'node2'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), ['node1', 'node2'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {'node2': '10.20.39.202'})
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), 'node2.ceph.com')
@@ -118,6 +149,7 @@ class ConfigShellTest(SaltMockTestCase):
                                                           'roles': ['mgr'],
                                                           'execution': {}})
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1', 'node2'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), ['node1', 'node2'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {})
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
@@ -214,6 +246,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertJsonInSysOut({
             'minions': {
                 'all': ['node1', 'node2'],
+                'admin': [],
                 'mgr': ['node1'],
                 'mon': {'node2': '10.20.39.202'}
             },
@@ -231,6 +264,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.fs.create_file('/config.json', contents=json.dumps({
             'minions': {
                 'all': ['node1', 'node2'],
+                'admin': [],
                 'mgr': ['node1'],
                 'mon': {'node2': '10.20.39.202'}
             },
@@ -248,6 +282,7 @@ class ConfigShellTest(SaltMockTestCase):
                                         'roles': ['mon'],
                                         'execution': {}})
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1', 'node2'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mgr'), ['node1'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:mon'), {'node2': '10.20.39.202'})
         self.assertIsNone(PillarManager.get('ceph-salt:bootstrap_minion'))
@@ -264,6 +299,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.fs.create_file('/config.json', contents=json.dumps({
             'minions': {
                 'all': ['node1', 'node2', 'node9'],
+                'admin': [],
                 'mgr': ['node1'],
                 'mon': {'node2': '10.20.39.202'}
             }}))

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -18,6 +18,10 @@ class ValidateConfigTest(SaltMockTestCase):
         PillarManager.reset('ceph-salt:bootstrap_minion')
         self.assertEqual(validate_config(), "At least one minion must be both 'Mgr' and 'Mon'")
 
+    def test_boostrap_minion_is_not_admin(self):
+        PillarManager.set('ceph-salt:minions:admin', [])
+        self.assertEqual(validate_config(), "Bootstrap minion must be 'Admin'")
+
     def test_no_ceph_container_image_path(self):
         PillarManager.reset('ceph-salt:container:images:ceph')
         self.assertEqual(validate_config(), "No Ceph container image path specified in config")
@@ -27,5 +31,6 @@ class ValidateConfigTest(SaltMockTestCase):
 
     @classmethod
     def create_valid_config(cls):
-        PillarManager.set('ceph-salt:bootstrap_minion', 'node1')
+        PillarManager.set('ceph-salt:bootstrap_minion', 'node1.ceph.com')
+        PillarManager.set('ceph-salt:minions:admin', 'node1')
         PillarManager.set('ceph-salt:container:images:ceph', 'docker.io/ceph/daemon-base:latest')


### PR DESCRIPTION
Instead of installing "ceph-tools [1]" on all "Mgr" nodes, we will now install those tools on"Admin" nodes.

Note that "Bootstrap" minion must be an "Admin" node.

[1] ceph.conf, keyring, and ceph-common[2]
[2] ceph-common will be replaced by an alias on https://github.com/ceph/ceph-salt/issues/120


Fixes: https://github.com/ceph/ceph-salt/issues/71

Signed-off-by: Ricardo Marques <rimarques@suse.com>