### PR TITLE
Use `cephadm pull` instead of `podman pull` 

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephtools.sls
@@ -19,7 +19,7 @@ install cephadm:
 download ceph container image:
   cmd.run:
     - name: |
-        podman pull {{ pillar['ceph-salt']['container']['images']['ceph'] }}
+        cephadm --image {{ pillar['ceph-salt']['container']['images']['ceph'] }} pull
     - failhard: True
 {{ macros.end_step('Download ceph container image') }}
 


### PR DESCRIPTION
Use `cephadm pull` instead of `podman pull`.

Signed-off-by: Ricardo Marques <rimarques@suse.com>