### PR TITLE
salt-formula: placement spec is now one single argument

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/ceph-mgr.sls
+++ b/ceph-salt-formula/salt/ceph-salt/ceph-mgr.sls
@@ -13,7 +13,7 @@
 deploy remaining mgrs:
   cmd.run:
     - name: |
-        ceph orch apply mgr {{ mgr_update_args | join(',') }}
+        ceph orch apply mgr "{{ mgr_update_args | join(',') }}"
     - failhard: True
 
 {{ macros.end_stage('Deployment of Ceph MGRs') }}


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

Handwaving, as I'm not sure about this.But this needs fixing since 

https://github.com/ceph/ceph/pull/33706

especially this commit: https://github.com/ceph/ceph/commit/42cf2e787fe76c8de015f0d452c1705792e63fba#diff-0ee00d94e4b572951e6b36df0216e98e

Fixes:

```
  stderr: 'Invalid command: unused arguments: [''host-063'', ''host-009'']

    orch apply mgr [<placement>] :  Update the size or placement of managers

    Error EINVAL: invalid command'
  stdout: ''
comment: 'Command "ceph orch apply mgr 2 host-063 host-009
```