### PR TITLE
configshell: Handle execution errors (e.g. Command not found)

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -847,7 +847,7 @@ def run_config_shell():
         try:
             shell.run_interactive()
             break
-        except CephSaltException as ex:
+        except (configshell.ExecutionError, CephSaltException) as ex:
             logger.exception(ex)
             PP.pl_red(ex)
     return True


### PR DESCRIPTION
Handle `configshell` execution errors.

![Screenshot from 2020-03-12 14-58-51](https://user-images.githubusercontent.com/14297426/76535089-3c5d0580-6472-11ea-986f-f1b75a8c9dfe.png)

Fixes: https://github.com/ceph/ceph-salt/issues/66

Signed-off-by: Ricardo Marques <rimarques@suse.com>