### PR TITLE
Always create ceph log dir

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
@@ -13,13 +13,6 @@ osd crush chooseleaf for single-node cluster:
 {{ macros.begin_stage('Ceph bootstrap') }}
 
 {% if grains['id'] == pillar['ceph-salt']['bootstrap_minion'] %}
-/var/log/ceph:
-  file.directory:
-    - user: ceph
-    - group: ceph
-    - mode: '0770'
-    - makedirs: True
-    - failhard: True
 
 {{ macros.begin_step('Wait for other minions') }}
 wait for other minions:

--- a/ceph-salt-formula/salt/ceph-salt/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephtools.sls
@@ -13,6 +13,16 @@ install cephadm:
     - failhard: True
 {% endif %}
 
+{% if grains['id'] == pillar['ceph-salt']['bootstrap_minion'] %}
+/var/log/ceph:
+  file.directory:
+    - user: ceph
+    - group: ceph
+    - mode: '0770'
+    - makedirs: True
+    - failhard: True
+{% endif %}
+
 {{ macros.end_step('Install cephadm and other packages') }}
 
 {{ macros.begin_step('Download ceph container image') }}

--- a/ceph-salt-formula/salt/ceph-salt/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephtools.sls
@@ -10,8 +10,8 @@ install cephadm:
         - cephadm
 {% if 'admin' in grains['ceph-salt']['roles'] %}
         - ceph-common
-    - failhard: True
 {% endif %}
+    - failhard: True
 
 {% if grains['id'] == pillar['ceph-salt']['bootstrap_minion'] %}
 /var/log/ceph:


### PR DESCRIPTION
Create '/var/log/ceph' even if 'ceph-salt:deploy:bootstrap' is disabled.

Also, make 'pkg.installed' failhard regarless of minion roles.