### PR TITLE
ceph-mgr.sls: do not omit bootstrap MGR from "ceph orch apply mgr"

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/ceph-mgr.sls
+++ b/ceph-salt-formula/salt/ceph-salt/ceph-mgr.sls
@@ -3,9 +3,7 @@
 {% if pillar['ceph-salt']['minions'].get('mgr', {}) | length > 1 %}
 {% set mgr_update_args = [] %}
 {% for minion in pillar['ceph-salt']['minions']['mgr'] %}
-{% if minion != grains['host'] %}
 {% if mgr_update_args.append(minion) %}{% endif %}
-{% endif %}
 {% endfor %}
 
 {{ macros.begin_stage('Deployment of Ceph MGRs') }}


### PR DESCRIPTION
With ceph v15.2.0 this code was having the effect of removing the
bootstrap MGR when adding additional MGRs, which of course is not
desired.

Signed-off-by: Nathan Cutler <ncutler@suse.com>