### PR TITLE
cephtools.sls: run "cephadm check-host" on all minions

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephtools.sls
@@ -25,6 +25,16 @@ install cephadm:
 
 {{ macros.end_step('Install cephadm and other packages') }}
 
+{{ macros.begin_step('Run "cephadm check-host"') }}
+
+have cephadm check the host:
+  cmd.run:
+    - name: |
+        cephadm check-host
+    - failhard: True
+
+{{ macros.end_step('Run "cephadm check-host"') }}
+
 {{ macros.begin_step('Download ceph container image') }}
 download ceph container image:
   cmd.run:


### PR DESCRIPTION
Given that cephadm has this functionality, it seems prudent to make use
of it.

Signed-off-by: Nathan Cutler <ncutler@suse.com>