### PR TITLE
chrony.conf.j2: do not add extra newlines to chrony.conf (FIXUP)

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/files/chrony.conf.j2
+++ b/ceph-salt-formula/salt/ceph-salt/files/chrony.conf.j2
@@ -11,10 +11,10 @@ manual
 {%- if salt['network.ip_in_subnet'](fqdn_ip, subnet) %}
 allow {{ subnet }}
 {%- endif %}
-{%- endfor %}  # subnet in salt['network.subnets']()
-{%- else %}    # grains['fqdn'] == time_server
+{%- endfor %}  {# subnet in salt['network.subnets']() #}
+{%- else %}    {# grains['fqdn'] == time_server #}
 server {{ time_server }} iburst
-{%- endif %}   # grains['fqdn'] == time_server
+{%- endif %}   {# grains['fqdn'] == time_server #}
 
 driftfile /var/lib/chrony/drift
 makestep 0.1 3


### PR DESCRIPTION
An untested version of the patch got merged by mistake - sorry about
that!

Fixes: b0ab0092490adf0f7cc769d5b546fc60b1754525
Signed-off-by: Nathan Cutler <ncutler@suse.com>