### PR TITLE
time.sls: run "chronyc makestep" before starting chrony.service

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/init.sls
@@ -6,6 +6,8 @@ include:
     - .software
     - .apparmor
     - .time
+    - .time-server
+    - .time-slave
     - .cephtools
     - .provision-end
 {% if pillar['ceph-salt'].get('deploy', {'bootstrap': True}).get('bootstrap', True) %}

--- a/ceph-salt-formula/salt/ceph-salt/time-server.sls
+++ b/ceph-salt-formula/salt/ceph-salt/time-server.sls
@@ -1,0 +1,31 @@
+{% if pillar['ceph-salt']['time_server'].get('enabled', True) %}
+
+{% import 'macros.yml' as macros %}
+
+{{ macros.begin_stage('Starting chrony and syncing clocks on time_server node') }}
+
+{% set time_server = pillar['ceph-salt']['time_server']['server_host'] %}
+{% if grains['fqdn'] == time_server %}
+
+start chronyd on time_server:
+  service.running:
+    - name: chronyd
+    - enable: True
+    - failhard: True
+
+sync time_server with external time servers:
+  cmd.run:
+    - name: |
+        chronyc makestep
+        chronyc waitsync
+    - failhard: True
+
+{% endif %}
+
+{{ macros.end_stage('Starting chrony and syncing clocks on time_server node') }}
+
+{% endif %}
+
+prevent empty file:
+  test.nop
+

--- a/ceph-salt-formula/salt/ceph-salt/time-slave.sls
+++ b/ceph-salt-formula/salt/ceph-salt/time-slave.sls
@@ -1,0 +1,32 @@
+{% if pillar['ceph-salt']['time_server'].get('enabled', True) %}
+
+{% import 'macros.yml' as macros %}
+
+{{ macros.begin_stage('Starting chrony and syncing clocks on time slave nodes') }}
+
+{% set time_server = pillar['ceph-salt']['time_server']['server_host'] %}
+
+{% if grains['fqdn'] != time_server %}
+
+start chronyd on slaves:
+  service.running:
+    - name: chronyd
+    - enable: True
+    - failhard: True
+
+sync slaves with time_server:
+  cmd.run:
+    - name: |
+        chronyc makestep
+        chronyc waitsync
+    - failhard: True
+
+{% endif %}
+
+{{ macros.end_stage('Starting chrony and syncing clocks on time slave nodes') }}
+
+{% endif %}
+
+prevent empty file:
+  test.nop
+

--- a/ceph-salt-formula/salt/ceph-salt/time.sls
+++ b/ceph-salt-formula/salt/ceph-salt/time.sls
@@ -33,18 +33,10 @@ service_reload:
 
 {{ macros.end_step('Configure chrony service') }}
 
-{{ macros.begin_step('Start chrony service') }}
-start chronyd:
-  service.running:
-    - name: chronyd
-    - enable: True
-    - failhard: True
-{{ macros.end_step('Start chrony service') }}
+{{ macros.end_stage('Setting up time synchronization') }}
 
 {% endif %}
 
 prevent empty file:
   test.nop
-
-{{ macros.end_stage('Setting up time synchronization') }}
 


### PR DESCRIPTION
By ensuring that chronyd is started and synced on time_server first,
and on the "chrony slaves", second (as opposed to doing it all at once,
in parallel), we prevent the cluster from starting up in "HEALTH_WARN
clock skew detected"

Fixes: https://github.com/ceph/ceph-salt/issues/141
Signed-off-by: Nathan Cutler <ncutler@suse.com>