### PR TITLE
Install private/public keys on admin nodes

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/sshkey.sls
+++ b/ceph-salt-formula/salt/ceph-salt/sshkey.sls
@@ -11,7 +11,7 @@
     - makedirs: True
     - failhard: True
 
-{% if 'mgr' in grains['ceph-salt']['roles'] %}
+{% if 'admin' in grains['ceph-salt']['roles'] %}
 # private key
 /root/.ssh/id_rsa:
   file.managed:


### PR DESCRIPTION
'Mgr' role no longer exists, so private and public keys must be set on 'Admin' nodes instead.

Signed-off-by: Ricardo Marques <rimarques@suse.com>