### PR TITLE
Allow explicit set bootstrap Mon IP

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
@@ -33,7 +33,7 @@ run cephadm bootstrap:
   cmd.run:
     - name: |
         CEPHADM_IMAGE={{ pillar['ceph-salt']['container']['images']['ceph'] }} \
-        cephadm --verbose bootstrap --mon-ip {{ grains['fqdn_ip4'][0] }} \
+        cephadm --verbose bootstrap --mon-ip {{ pillar['ceph-salt']['bootstrap_mon_ip'] }} \
                 --config /tmp/bootstrap-ceph.conf \
                 --initial-dashboard-user {{ dashboard_username }} \
                 --output-keyring /etc/ceph/ceph.client.admin.keyring \

--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -61,10 +61,15 @@ class PillarHandler(OptionHandler):
         return False
 
 
-class MinionPillarHandler(PillarHandler):
+class BootstrapMinionHandler(PillarHandler):
+    def __init__(self):
+        super().__init__('ceph-salt:bootstrap_minion')
+
     def save(self, value):
         if value not in self.possible_values():
             raise MinionDoesNotExistInConfiguration(value)
+        node = CephNodeManager.ceph_salt_nodes()[value]
+        PillarManager.set('ceph-salt:bootstrap_mon_ip', node.public_ip)
         super().save(value)
 
     def possible_values(self):
@@ -316,7 +321,7 @@ CEPH_SALT_OPTIONS = {
                     },
                     'Bootstrap': {
                         'help': 'Cluster\'s first Mon and Mgr',
-                        'handler': MinionPillarHandler('ceph-salt:bootstrap_minion'),
+                        'handler': BootstrapMinionHandler(),
                         'required': True,
                         'default_text': 'no minion',
                         'default': None
@@ -397,7 +402,12 @@ CEPH_SALT_OPTIONS = {
                         'handler': PillarHandler('ceph-salt:dashboard:username')
                     }
                 }
-            }
+            },
+            'Mon_IP': {
+                'help': 'Bootstrap Mon IP',
+                'default': None,
+                'handler': PillarHandler('ceph-salt:bootstrap_mon_ip')
+            },
         }
     },
     'SSH': {

--- a/ceph_salt/core.py
+++ b/ceph_salt/core.py
@@ -5,7 +5,7 @@ import hashlib
 
 from Cryptodome.PublicKey import RSA
 
-from .exceptions import CephNodeHasRolesException, CephNodeFqdnResolvesToLoopbackException
+from .exceptions import CephNodeHasRolesException
 from .salt_utils import SaltClient, GrainsManager, PillarManager
 
 
@@ -86,8 +86,6 @@ class CephNodeManager:
     def add_node(cls, minion_id):
         cls._load()
         node = CephNode(minion_id)
-        if not node.public_ip or node.public_ip == '127.0.0.1':
-            raise CephNodeFqdnResolvesToLoopbackException(minion_id)
         node.save()
         cls._ceph_salt_nodes[minion_id] = node
         cls.save_in_pillar()

--- a/ceph_salt/exceptions.py
+++ b/ceph_salt/exceptions.py
@@ -8,12 +8,6 @@ class CephNodeHasRolesException(CephSaltException):
             "Cannot remove host '{}' because it has roles defined: {}".format(minion_id, roles))
 
 
-class CephNodeFqdnResolvesToLoopbackException(CephSaltException):
-    def __init__(self, minion_id):
-        super(CephNodeFqdnResolvesToLoopbackException, self).__init__(
-            "Host '{}' FQDN resolves to the loopback interface IP address".format(minion_id))
-
-
 class SaltCallException(CephSaltException):
     def __init__(self, target, func, ret):
         super(SaltCallException, self).__init__(

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -14,6 +14,11 @@ def validate_config(host_ls):
         bootstrap_minion_short_name = bootstrap_minion.split('.', 1)[0]
         if bootstrap_minion_short_name not in admin_nodes:
             return "Bootstrap minion must be 'Admin'"
+    bootstrap_mon_ip = PillarManager.get('ceph-salt:bootstrap_mon_ip')
+    if not bootstrap_mon_ip:
+        return "No bootstrap Mon IP specified in config"
+    if bootstrap_mon_ip in ['127.0.0.1', '::1']:
+        return 'Mon IP cannot be the loopback interface IP'
     all_nodes = PillarManager.get('ceph-salt:minions:all')
     for admin_node in admin_nodes:
         if admin_node not in all_nodes:

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -45,17 +45,6 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
 
-    def test_ceph_cluster_minions_add_invalid_ip(self):
-        fqdn_ip4 = GrainsManager.get_grain('node1.ceph.com', 'fqdn_ip4')
-        GrainsManager.set_grain('node1.ceph.com', 'fqdn_ip4', ['127.0.0.1'])
-
-        self.shell.run_cmdline('/Ceph_Cluster/Minions add node1.ceph.com')
-        self.assertInSysOut("Host 'node1.ceph.com' FQDN resolves to the loopback interface IP "
-                            "address")
-        self.assertIsNone(PillarManager.get('ceph-salt:minions:all'))
-
-        GrainsManager.set_grain('node1.ceph.com', 'fqdn_ip4', fqdn_ip4)
-
     def test_ceph_cluster_minions_rm_with_roles(self):
         self.shell.run_cmdline('/Ceph_Cluster/Minions add node1.ceph.com')
         self.shell.run_cmdline('/Ceph_Cluster/Roles/Admin add node1.ceph.com')

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -24,6 +24,14 @@ class ValidateConfigTest(SaltMockTestCase):
         self.assertEqual(validate_config([]), "Bootstrap minion must be 'Admin'")
         self.assertEqual(validate_config([{'hostname': 'node1'}]), None)
 
+    def test_no_bootstrap_mon_ip(self):
+        PillarManager.reset('ceph-salt:bootstrap_mon_ip')
+        self.assertEqual(validate_config([]), "No bootstrap Mon IP specified in config")
+
+    def test_loopback_bootstrap_mon_ip(self):
+        PillarManager.set('ceph-salt:bootstrap_mon_ip', '127.0.0.1')
+        self.assertEqual(validate_config([]), "Mon IP cannot be the loopback interface IP")
+
     def test_admin_not_cluster_minion(self):
         PillarManager.set('ceph-salt:bootstrap_minion', 'node3.ceph.com')
         PillarManager.set('ceph-salt:minions:admin', ['node3'])
@@ -39,6 +47,7 @@ class ValidateConfigTest(SaltMockTestCase):
     @classmethod
     def create_valid_config(cls):
         PillarManager.set('ceph-salt:bootstrap_minion', 'node1.ceph.com')
+        PillarManager.set('ceph-salt:bootstrap_mon_ip', '10.20.188.201')
         PillarManager.set('ceph-salt:minions:all', ['node1', 'node2'])
         PillarManager.set('ceph-salt:minions:admin', ['node1'])
         PillarManager.set('ceph-salt:container:images:ceph', 'docker.io/ceph/daemon-base:latest')


### PR DESCRIPTION
This PR will allow the user to explicitly set the "Mon IP" used on `cephadm bootstrap --mon-ip <Mon_IP>` command option, instead of always use the IP address return by `fqdn_ip4` salt grain (which forces the user to edit the `/etc/hosts` file).

Note that, for better usability,  when `/Ceph_Cluster/Roles/Bootstrap` minion is set by the user, `ceph-salt`will automatically set `/Cephadm_Bootstrap/Mon_IP` with the IP address return by `fqdn_ip4` salt grain.

```
master:~ # ceph-salt config /Cephadm_Bootstrap ls
o- Cephadm_Bootstrap .......................................................... [enabled]
  o- Ceph_Conf .................................................................... [...]
  o- Dashboard .................................................................... [...]
  | o- password ................................................................... [***]
  | o- username ................................................................. [admin]
  o- Mon_IP .............................................................. [10.20.75.201]
```

Fixes: https://github.com/ceph/ceph-salt/issues/64

Signed-off-by: Ricardo Marques <rimarques@suse.com>