### PR TITLE
Fix "status" error when ceph_orch salt module is not available

### DIFF
--- a/ceph_salt/salt_utils.py
+++ b/ceph_salt/salt_utils.py
@@ -301,6 +301,6 @@ class CephOrch:
         result = SaltClient.local().cmd('ceph-salt:member', 'ceph_orch.configured',
                                         tgt_type='grain')
         for minion, value in result.items():
-            if value:
+            if value is True:
                 return SaltClient.local_cmd(minion, 'ceph_orch.host_ls')[minion]
         return []


### PR DESCRIPTION
How to reproduce:

Install `ceph-salt` but don't update salt modules (e.g., don't run `salt '*' saltutil.sync_all`).

Run `ceph-salt status` command:

```
master:~ # ceph-salt status
Traceback (most recent call last):
  File "/usr/bin/ceph-salt", line 11, in <module>
    load_entry_point('ceph-salt==15.2.0', 'console_scripts', 'ceph-salt')()
  File "/usr/lib/python3.6/site-packages/ceph_salt/__init__.py", line 55, in ceph_salt_main
    cli(prog_name='ceph-salt')
  File "/usr/lib64/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib64/python3.6/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/lib64/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib64/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib64/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/ceph_salt/__init__.py", line 98, in status
    if not run_status():
  File "/usr/lib/python3.6/site-packages/ceph_salt/config_shell.py", line 965, in run_status
    ceph_salt_nodes, deployed_nodes, not_managed_nodes = count_hosts(host_ls)
  File "/usr/lib/python3.6/site-packages/ceph_salt/config_shell.py", line 952, in count_hosts
    if host['hostname'] in all_nodes:
TypeError: string indices must be integers
```

Note that `ceph_orch` module is not available:
```
master:~ # salt -G ceph-salt:member ceph_orch.configured
node2.octopus.com:
    'ceph_orch.configured' is not available.
node3.octopus.com:
    'ceph_orch.configured' is not available.
node1.octopus.com:
    'ceph_orch.configured' is not available.
master.octopus.com:
    'ceph_orch.configured' is not available.
ERROR: Minions returned with non-zero exit code

master:~ # salt -G ceph-salt:member ceph_orch.host_ls
node2.octopus.com:
    'ceph_orch.host_ls' is not available.
node3.octopus.com:
    'ceph_orch.host_ls' is not available.
node1.octopus.com:
    'ceph_orch.host_ls' is not available.
master.octopus.com:
    'ceph_orch.host_ls' is not available.
ERROR: Minions returned with non-zero exit code
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>