### PR TITLE
Support salt 3000

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,8 @@ install_requires =
     configshell-fb >= 1.1
     pycryptodomex >= 3.4.6
     PyYAML >= 5.1.2
-    salt < 3000
+    salt >= 2019.2.0
+    tornado >= 4.2.1, < 5.0
 
 packages =
     ceph_salt


### PR DESCRIPTION
How to test `salt-3000` using sesdev:

```
$ cat ~/.sesdev/config.yaml
version_os_repo_mapping:
    octopus:
        leap-15.2:
            - 'http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/next:/testing/openSUSE_Leap_15.2'
    ses7:
        sles-15-sp2:
            - 'http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/next:/testing/SLE_15_SP2'

$ sesdev create octopus --ceph-salt-repo https://github.com/ricardoasmarques/ceph-salt.git --ceph-salt-branch salt-3000 octopus-salt-3000

$ sesdev create ses7 --ceph-salt-repo https://github.com/ricardoasmarques/ceph-salt.git --ceph-salt-branch salt-3000 ses7-salt-3000
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>