### PR TITLE
Support quoted string values

### DIFF
--- a/ceph_salt/__init__.py
+++ b/ceph_salt/__init__.py
@@ -79,6 +79,11 @@ def config_shell(config_args):
     Starts ceph-salt configuration shell
     """
     if config_args:
+        def _quote(text):
+            if ' ' in text:
+                return '"{}"'.format(text)
+            return text
+        config_args = [_quote(config_arg) for config_arg in config_args]
         if not run_config_cmdline(" ".join(config_args)):
             sys.exit(1)
     else:

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -243,15 +243,15 @@ class ConfigShellTest(SaltMockTestCase):
         sec_path = '{}/{}'.format(path, 'section1')
         sec_pillar_key = '{}:{}'.format(pillar_key, 'section1')
 
-        self.shell.run_cmdline('{} set my option1 = 2'.format(sec_path))
+        self.shell.run_cmdline('{} set "my option1" 2'.format(sec_path))
         self.assertInSysOut('Parameter set.')
         self.assertEqual(PillarManager.get(sec_pillar_key), {'my option1': '2'})
 
-        self.shell.run_cmdline('{} set my option2 = 3'.format(sec_path))
+        self.shell.run_cmdline('{} set "my option2" 3'.format(sec_path))
         self.assertInSysOut('Parameter set.')
         self.assertEqual(PillarManager.get(sec_pillar_key), {'my option1': '2', 'my option2': '3'})
 
-        self.shell.run_cmdline('{} remove my option1'.format(sec_path))
+        self.shell.run_cmdline('{} remove "my option1"'.format(sec_path))
         self.assertInSysOut('Parameter removed.')
         self.assertEqual(PillarManager.get(sec_pillar_key), {'my option2': '3'})
 


### PR DESCRIPTION
This PR adds proper support for strings with spaces by allowing to specify quoted strings.

Note that our parser is now using exactly the same `Word` as `configshell-fb`[1], but also supports quoted strings.

With this PR we will be able to fix https://github.com/ceph/ceph-salt/pull/113#discussion_r402032528 and also improve our `ConfSectionNode` because we will no longer use the `=` char which is a reserved char for `configshell`.

This also means that the following command:

```
ceph-salt config /Cephadm_Bootstrap/Ceph_Conf/global set osd crush chooseleaf type = 0
```

will change to:

```
ceph-salt config /Cephadm_Bootstrap/Ceph_Conf/global set "osd crush chooseleaf type" 0
```

As a result, we also improve usability by having more explicit parameters on `set` command:
```
# ceph-salt config /Cephadm_Bootstrap/Ceph_Conf/global help
  ...
  - set parameter value 
  - remove parameter
```


[1] https://github.com/open-iscsi/configshell-fb/blob/master/configshell/shell.py#L116

Signed-off-by: Ricardo Marques <rimarques@suse.com>

---

To Do:

- [x] after this PR is merged, merge https://github.com/SUSE/sesdev/pull/224