### PR TITLE
Allow explicit set chrony subnet

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/files/chrony.conf.j2
+++ b/ceph-salt-formula/salt/ceph-salt/files/chrony.conf.j2
@@ -7,12 +7,7 @@ pool {{ server }} iburst
 
 local stratum 10
 manual
-{%- set fqdn_ip = grains['fqdn_ip4'] %}
-{%- for subnet in salt['network.subnets']() %}
-{%- if salt['network.ip_in_subnet'](fqdn_ip, subnet) %}
-allow {{ subnet }}
-{%- endif %}
-{%- endfor %}  {# subnet in salt['network.subnets']() #}
+allow {{ pillar['ceph-salt']['time_server']['subnet'] }}
 {%- else %}    {# grains['fqdn'] == time_server #}
 server {{ time_server }} iburst
 {%- endif %}   {# grains['fqdn'] == time_server #}

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -19,6 +19,12 @@ def validate_config(host_ls):
         return "No bootstrap Mon IP specified in config"
     if bootstrap_mon_ip in ['127.0.0.1', '::1']:
         return 'Mon IP cannot be the loopback interface IP'
+    time_server_host = PillarManager.get('ceph-salt:time_server:server_host')
+    if not time_server_host:
+        return 'No time server host specified in config'
+    time_server_subnet = PillarManager.get('ceph-salt:time_server:subnet')
+    if not time_server_subnet:
+        return 'No time server subnet specified in config'
     all_nodes = PillarManager.get('ceph-salt:minions:all')
     for admin_node in admin_nodes:
         if admin_node not in all_nodes:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -138,6 +138,14 @@ class CephOrchMock:
         return cls.host_ls_result
 
 
+class NetworkMock:
+    subnets_result = []
+
+    @classmethod
+    def subnets(cls):
+        return cls.subnets_result
+
+
 class SaltLocalClientMock:
 
     def __init__(self):
@@ -174,6 +182,8 @@ class SaltLocalClientMock:
                 result[tgt] = getattr(ServiceMock, func)(*args)
             elif mod == 'ceph_orch':
                 result[tgt] = getattr(CephOrchMock, func)(*args)
+            elif mod == 'network':
+                result[tgt] = getattr(NetworkMock, func)(*args)
             else:
                 raise NotImplementedError()
 

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -32,6 +32,14 @@ class ValidateConfigTest(SaltMockTestCase):
         PillarManager.set('ceph-salt:bootstrap_mon_ip', '127.0.0.1')
         self.assertEqual(validate_config([]), "Mon IP cannot be the loopback interface IP")
 
+    def test_no_time_server_host(self):
+        PillarManager.reset('ceph-salt:time_server:server_host')
+        self.assertEqual(validate_config([]), "No time server host specified in config")
+
+    def test_no_time_server_subnet(self):
+        PillarManager.reset('ceph-salt:time_server:subnet')
+        self.assertEqual(validate_config([]), "No time server subnet specified in config")
+
     def test_admin_not_cluster_minion(self):
         PillarManager.set('ceph-salt:bootstrap_minion', 'node3.ceph.com')
         PillarManager.set('ceph-salt:minions:admin', ['node3'])
@@ -48,6 +56,8 @@ class ValidateConfigTest(SaltMockTestCase):
     def create_valid_config(cls):
         PillarManager.set('ceph-salt:bootstrap_minion', 'node1.ceph.com')
         PillarManager.set('ceph-salt:bootstrap_mon_ip', '10.20.188.201')
+        PillarManager.set('ceph-salt:time_server:server_host', 'node1.ceph.com')
+        PillarManager.set('ceph-salt:time_server:subnet', '10.20.188.0/24')
         PillarManager.set('ceph-salt:minions:all', ['node1', 'node2'])
         PillarManager.set('ceph-salt:minions:admin', ['node1'])
         PillarManager.set('ceph-salt:container:images:ceph', 'docker.io/ceph/daemon-base:latest')


### PR DESCRIPTION
Instead of relying on `fqdn_ipv4` grain, it's now possible to explicitly set the time server subnet:

```
o- Time_Server ........................................................................... [enabled]
  o- External_Servers .......................................................................... [1]
  | o- 0.pt.pool.ntp.org ..................................................................... [...]
  o- Server_Hostname .......................................................... [master.octopus.com]
  o- Subnet ........................................................................ [10.20.91.0/24]
```
 
Note that for convenience, `ceph-salt` will automatically set the `Subnet` when `Server_Hostname` is set by the user.

Also, when typing `set <tab>`, `ceph-salt` will sugest/auto-complete possible subnet values.

Fixes: https://github.com/ceph/ceph-salt/issues/161

Signed-off-by: Ricardo Marques <rimarques@suse.com>