### PR TITLE
Use lowecase on config nodes

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -89,8 +89,8 @@ class RoleElementHandler(OptionHandler):
     def value(self):
         roles = CephNodeManager.all_roles(self.ceph_salt_node)
         if not roles - {self.role}:
-            return 'no other roles', None
-        return "other roles: {}".format(", ".join(roles - {self.role})), None
+            return 'No other roles', None
+        return "Other roles: {}".format(", ".join(roles - {self.role})), None
 
 
 class RoleHandler(OptionHandler):
@@ -291,7 +291,7 @@ class TimeServerHandler(PillarHandler):
 
 
 CEPH_SALT_OPTIONS = {
-    'Ceph_Cluster': {
+    'ceph_cluster': {
         'help': '''
                 Cluster Options Configuration
                 ====================================
@@ -299,13 +299,13 @@ CEPH_SALT_OPTIONS = {
                 membership, roles, etc...
                 ''',
         'options': {
-            'Minions': {
+            'minions': {
                 'help': 'The list of salt minions that are used to deploy Ceph',
                 'default': [],
                 'type': 'minions',
                 'handler': CephSaltNodesHandler()
             },
-            'Roles': {
+            'roles': {
                 'type': 'group',
                 'handler': RolesGroupHandler(),
                 'help': '''
@@ -313,13 +313,13 @@ CEPH_SALT_OPTIONS = {
                         ====================================
                         ''',
                 'options': {
-                    'Admin': {
+                    'admin': {
                         'type': 'minions',
                         'default': [],
                         'handler': RoleHandler('admin'),
                         'help': 'List of minions with Admin role'
                     },
-                    'Bootstrap': {
+                    'bootstrap': {
                         'help': 'Cluster\'s first Mon and Mgr',
                         'handler': BootstrapMinionHandler(),
                         'required': True,
@@ -330,7 +330,7 @@ CEPH_SALT_OPTIONS = {
             },
         }
     },
-    'Containers': {
+    'containers': {
         'help': '''
                 Container Options Configuration
                 ====================================
@@ -338,7 +338,7 @@ CEPH_SALT_OPTIONS = {
                 for deployment.
                 ''',
         'options': {
-            'Images': {
+            'images': {
                 'type': 'group',
                 'help': "Container images paths",
                 'options': {
@@ -352,20 +352,20 @@ CEPH_SALT_OPTIONS = {
             },
         }
     },
-    'System_Update': {
+    'system_update': {
         'help': '''
                 System Update Options Configuration
                 =========================================
                 Options to control system updates
                 ''',
         'options': {
-            'Packages': {
+            'packages': {
                 'type': 'flag',
                 'help': 'Update all packages',
                 'handler': PillarHandler('ceph-salt:updates:enabled'),
                 'default': True
             },
-            'Reboot': {
+            'reboot': {
                 'type': 'flag',
                 'help': 'Reboot if needed',
                 'handler': PillarHandler('ceph-salt:updates:reboot'),
@@ -373,7 +373,7 @@ CEPH_SALT_OPTIONS = {
             }
         }
     },
-    'Cephadm_Bootstrap': {
+    'cephadm_bootstrap': {
         'help': '''
                 Cluster Bootstrap Options Configuration
                 =========================================
@@ -381,13 +381,13 @@ CEPH_SALT_OPTIONS = {
                 ''',
         'handler': FlagGroupPillarHandler('ceph-salt:bootstrap_enabled', True),
         'options': {
-            'Ceph_Conf': {
+            'ceph_conf': {
                 'type': 'conf',
                 'help': 'Bootstrap Ceph configuration',
                 'default': [],
                 'handler': PillarHandler('ceph-salt:bootstrap_ceph_conf')
             },
-            'Dashboard': {
+            'dashboard': {
                 'type': 'group',
                 'help': 'Dashboard settings',
                 'options': {
@@ -403,14 +403,14 @@ CEPH_SALT_OPTIONS = {
                     }
                 }
             },
-            'Mon_IP': {
+            'mon_ip': {
                 'help': 'Bootstrap Mon IP',
                 'default': None,
                 'handler': PillarHandler('ceph-salt:bootstrap_mon_ip')
             },
         }
     },
-    'SSH': {
+    'ssh': {
         'help': '''
                 SSH Keys configuration
                 ============================
@@ -418,19 +418,19 @@ CEPH_SALT_OPTIONS = {
                 ''',
         'handler': SSHGroupHandler(),
         'options': {
-            'Private_Key': {
+            'private_key': {
                 'default': None,
                 'help': "SSH RSA private key",
                 'handler': SshPrivateKeyHandler()
             },
-            'Public_Key': {
+            'public_key': {
                 'default': None,
                 'help': "SSH RSA public key",
                 'handler': SshPublicKeyHandler()
             },
         }
     },
-    'Time_Server': {
+    'time_server': {
         'help': '''
                 Time Server Deployment Options
                 ==============================
@@ -438,13 +438,13 @@ CEPH_SALT_OPTIONS = {
                 ''',
         'handler': TimeServerGroupHandler(),
         'options': {
-            'External_Servers': {
+            'external_servers': {
                 'type': 'list',
                 'default': [],
                 'help': 'List of external NTP servers',
                 'handler': PillarHandler('ceph-salt:time_server:external_time_servers')
             },
-            'Server_Hostname': {
+            'server_hostname': {
                 'default': None,
                 'help': 'FQDN of the time server node',
                 'handler': TimeServerHandler('ceph-salt:time_server:server_host'),

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -29,7 +29,7 @@ class ConfigShellTest(SaltMockTestCase):
         PillarManager.reload()
 
     def test_ceph_cluster_minions(self):
-        self.shell.run_cmdline('/Ceph_Cluster/Minions add node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions add node1.ceph.com')
         self.assertInSysOut('1 minion added.')
         self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True,
                                                           'roles': [],
@@ -38,7 +38,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
 
-        self.shell.run_cmdline('/Ceph_Cluster/Minions rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions rm node1.ceph.com')
         self.assertInSysOut('1 minion removed.')
         self.assertNotInGrains('node1.ceph.com', 'ceph-salt')
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), [])
@@ -46,25 +46,25 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
 
     def test_ceph_cluster_minions_rm_with_roles(self):
-        self.shell.run_cmdline('/Ceph_Cluster/Minions add node1.ceph.com')
-        self.shell.run_cmdline('/Ceph_Cluster/Roles/Admin add node1.ceph.com')
-        self.shell.run_cmdline('/Ceph_Cluster/Roles/Bootstrap set node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions add node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/roles/admin add node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/roles/bootstrap set node1.ceph.com')
         self.clearSysOut()
 
-        self.shell.run_cmdline('/Ceph_Cluster/Minions rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions rm node1.ceph.com')
         self.assertInSysOut("Cannot remove host 'node1.ceph.com' because it has roles defined: "
                             "['admin', 'bootstrap']")
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
 
-        self.shell.run_cmdline('/Ceph_Cluster/Roles/Admin rm node1.ceph.com')
-        self.shell.run_cmdline('/Ceph_Cluster/Roles/Bootstrap reset')
-        self.shell.run_cmdline('/Ceph_Cluster/Minions rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/roles/admin rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/roles/bootstrap reset')
+        self.shell.run_cmdline('/ceph_cluster/minions rm node1.ceph.com')
 
     def test_ceph_cluster_roles_admin(self):
-        self.shell.run_cmdline('/Ceph_Cluster/Minions add node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions add node1.ceph.com')
         self.clearSysOut()
 
-        self.shell.run_cmdline('/Ceph_Cluster/Roles/Admin add node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/roles/admin add node1.ceph.com')
         self.assertInSysOut('1 minion added.')
         self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True,
                                                           'roles': ['admin'],
@@ -73,7 +73,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), ['node1'])
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
 
-        self.shell.run_cmdline('/Ceph_Cluster/Roles/Admin rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/roles/admin rm node1.ceph.com')
         self.assertInSysOut('1 minion removed.')
         self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True,
                                                           'roles': [],
@@ -82,15 +82,15 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
 
-        self.shell.run_cmdline('/Ceph_Cluster/Minions rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions rm node1.ceph.com')
 
     def test_ceph_cluster_roles_bootstrap(self):
         with pytest.raises(MinionDoesNotExistInConfiguration):
-            self.shell.run_cmdline('/Ceph_Cluster/Roles/Bootstrap set node1.ceph.com')
-        self.shell.run_cmdline('/Ceph_Cluster/Minions add node1.ceph.com')
+            self.shell.run_cmdline('/ceph_cluster/roles/bootstrap set node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions add node1.ceph.com')
         self.clearSysOut()
 
-        self.shell.run_cmdline('/Ceph_Cluster/Roles/Bootstrap set node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/roles/bootstrap set node1.ceph.com')
         self.assertInSysOut('Value set.')
         self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True,
                                                           'roles': [],
@@ -99,7 +99,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), 'node1.ceph.com')
 
-        self.shell.run_cmdline('/Ceph_Cluster/Roles/Bootstrap reset')
+        self.shell.run_cmdline('/ceph_cluster/roles/bootstrap reset')
         self.assertInSysOut('Value reset.')
         self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True,
                                                           'roles': [],
@@ -108,75 +108,75 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
 
-        self.shell.run_cmdline('/Ceph_Cluster/Minions rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions rm node1.ceph.com')
 
     def test_containers_images_ceph(self):
-        self.assertValueOption('/Containers/Images/ceph',
+        self.assertValueOption('/containers/images/ceph',
                                'ceph-salt:container:images:ceph',
                                'myvalue')
 
     def test_cephadm_bootstrap(self):
-        self.assertFlagOption('/Cephadm_Bootstrap',
+        self.assertFlagOption('/cephadm_bootstrap',
                               'ceph-salt:bootstrap_enabled')
 
     def test_cephadm_bootstrap_ceph_conf(self):
-        self.assertConfigOption('/Cephadm_Bootstrap/Ceph_Conf',
+        self.assertConfigOption('/cephadm_bootstrap/ceph_conf',
                                 'ceph-salt:bootstrap_ceph_conf')
 
     def test_cephadm_bootstrap_dashboard_password(self):
-        self.assertValueOption('/Cephadm_Bootstrap/Dashboard/password',
+        self.assertValueOption('/cephadm_bootstrap/dashboard/password',
                                'ceph-salt:dashboard:password',
                                'mypassword')
 
     def test_cephadm_bootstrap_dashboard_username(self):
-        self.assertValueOption('/Cephadm_Bootstrap/Dashboard/username',
+        self.assertValueOption('/cephadm_bootstrap/dashboard/username',
                                'ceph-salt:dashboard:username',
                                'myusername')
 
     def test_ssh(self):
-        self.shell.run_cmdline('/SSH generate')
+        self.shell.run_cmdline('/ssh generate')
         self.assertInSysOut('Key pair generated.')
         self.assertNotEqual(PillarManager.get('ceph-salt:ssh:private_key'), None)
         self.assertNotEqual(PillarManager.get('ceph-salt:ssh:public_key'), None)
 
     def test_ssh_private_key(self):
-        self.assertValueOption('/SSH/Private_Key',
+        self.assertValueOption('/ssh/private_key',
                                'ceph-salt:ssh:private_key',
                                'myprivatekey')
 
     def test_ssh_public_key(self):
-        self.assertValueOption('/SSH/Public_Key',
+        self.assertValueOption('/ssh/public_key',
                                'ceph-salt:ssh:public_key',
                                'mypublickey')
 
     def test_time_server(self):
-        self.assertFlagOption('/Time_Server',
+        self.assertFlagOption('/time_server',
                               'ceph-salt:time_server:enabled',
                               False)
 
     def test_time_server_external_servers(self):
-        self.assertListOption('/Time_Server/External_Servers',
+        self.assertListOption('/time_server/external_servers',
                               'ceph-salt:time_server:external_time_servers',
                               ['server1', 'server2'])
 
     def test_time_server_server_hostname(self):
-        self.assertValueOption('/Time_Server/Server_Hostname',
+        self.assertValueOption('/time_server/server_hostname',
                                'ceph-salt:time_server:server_host',
                                'server1')
 
     def test_system_update_packages(self):
-        self.assertFlagOption('/System_Update/Packages',
+        self.assertFlagOption('/system_update/packages',
                               'ceph-salt:updates:enabled')
 
     def test_system_update_reboot(self):
-        self.assertFlagOption('/System_Update/Reboot',
+        self.assertFlagOption('/system_update/reboot',
                               'ceph-salt:updates:reboot')
 
     def test_export(self):
-        self.shell.run_cmdline('/Ceph_Cluster/Minions add node1.ceph.com')
-        self.shell.run_cmdline('/Ceph_Cluster/Minions add node2.ceph.com')
-        self.shell.run_cmdline('/Ceph_Cluster/Roles/Admin add node1.ceph.com')
-        self.shell.run_cmdline('/Time_Server/Server_Hostname set server1')
+        self.shell.run_cmdline('/ceph_cluster/minions add node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions add node2.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/roles/admin add node1.ceph.com')
+        self.shell.run_cmdline('/time_server/server_hostname set server1')
         self.clearSysOut()
 
         self.assertTrue(run_export(False))
@@ -189,10 +189,10 @@ class ConfigShellTest(SaltMockTestCase):
                 'server_host': 'server1'
             }})
 
-        self.shell.run_cmdline('/Time_Server/Server_Hostname reset')
-        self.shell.run_cmdline('/Ceph_Cluster/Roles/Admin rm node1.ceph.com')
-        self.shell.run_cmdline('/Ceph_Cluster/Minions rm node2.ceph.com')
-        self.shell.run_cmdline('/Ceph_Cluster/Minions rm node1.ceph.com')
+        self.shell.run_cmdline('/time_server/server_hostname reset')
+        self.shell.run_cmdline('/ceph_cluster/roles/admin rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions rm node2.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions rm node1.ceph.com')
 
     def test_import(self):
         self.fs.create_file('/config.json', contents=json.dumps({
@@ -218,10 +218,10 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertIsNone(PillarManager.get('ceph-salt:bootstrap_minion'))
         self.assertEqual(PillarManager.get('ceph-salt:time_server:server_host'), 'server1')
 
-        self.shell.run_cmdline('/Time_Server/Server_Hostname reset')
-        self.shell.run_cmdline('/Ceph_Cluster/Roles/Admin rm node1.ceph.com')
-        self.shell.run_cmdline('/Ceph_Cluster/Minions rm node2.ceph.com')
-        self.shell.run_cmdline('/Ceph_Cluster/Minions rm node1.ceph.com')
+        self.shell.run_cmdline('/time_server/server_hostname reset')
+        self.shell.run_cmdline('/ceph_cluster/roles/admin rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions rm node2.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions rm node1.ceph.com')
         self.fs.remove('/config.json')
 
     def test_import_invalid_host(self):


### PR DESCRIPTION
Using lower-case on config tree nodes is easier to type during navigation (e.g. `cd /ceph_cluster/minions`), and consistent with other tools like `targetcli` and `gwcli`.

Signed-off-by: Ricardo Marques <rimarques@suse.com>