### PR TITLE
Rename minions "rm" command to "remove"

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -785,7 +785,7 @@ class MinionsOptionNode(OptionNode):
             MinionOptionNode(value, option_dict['handler'].children_handler(value), self)
 
     def _list_commands(self):
-        return ['add', 'rm']
+        return ['add', 'remove']
 
     def summary(self):
         value_list, val_type = self._find_value()
@@ -818,7 +818,7 @@ class MinionsOptionNode(OptionNode):
         elif not has_errors:
             PP.pl_red('No minions matched "{}".'.format(minion_id))
 
-    def ui_command_rm(self, minion_id):
+    def ui_command_remove(self, minion_id):
         matching = fnmatch.filter(self.value, minion_id)
         counter = 0
         has_errors = False

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -38,27 +38,27 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
 
-        self.shell.run_cmdline('/ceph_cluster/minions rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions remove node1.ceph.com')
         self.assertInSysOut('1 minion removed.')
         self.assertNotInGrains('node1.ceph.com', 'ceph-salt')
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), [])
         self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
 
-    def test_ceph_cluster_minions_rm_with_roles(self):
+    def test_ceph_cluster_minions_remove_with_roles(self):
         self.shell.run_cmdline('/ceph_cluster/minions add node1.ceph.com')
         self.shell.run_cmdline('/ceph_cluster/roles/admin add node1.ceph.com')
         self.shell.run_cmdline('/ceph_cluster/roles/bootstrap set node1.ceph.com')
         self.clearSysOut()
 
-        self.shell.run_cmdline('/ceph_cluster/minions rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions remove node1.ceph.com')
         self.assertInSysOut("Cannot remove host 'node1.ceph.com' because it has roles defined: "
                             "['admin', 'bootstrap']")
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
 
-        self.shell.run_cmdline('/ceph_cluster/roles/admin rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/roles/admin remove node1.ceph.com')
         self.shell.run_cmdline('/ceph_cluster/roles/bootstrap reset')
-        self.shell.run_cmdline('/ceph_cluster/minions rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions remove node1.ceph.com')
 
     def test_ceph_cluster_roles_admin(self):
         self.shell.run_cmdline('/ceph_cluster/minions add node1.ceph.com')
@@ -73,7 +73,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), ['node1'])
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
 
-        self.shell.run_cmdline('/ceph_cluster/roles/admin rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/roles/admin remove node1.ceph.com')
         self.assertInSysOut('1 minion removed.')
         self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True,
                                                           'roles': [],
@@ -82,7 +82,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
 
-        self.shell.run_cmdline('/ceph_cluster/minions rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions remove node1.ceph.com')
 
     def test_ceph_cluster_roles_bootstrap(self):
         with pytest.raises(MinionDoesNotExistInConfiguration):
@@ -108,7 +108,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
 
-        self.shell.run_cmdline('/ceph_cluster/minions rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions remove node1.ceph.com')
 
     def test_containers_images_ceph(self):
         self.assertValueOption('/containers/images/ceph',
@@ -190,9 +190,9 @@ class ConfigShellTest(SaltMockTestCase):
             }})
 
         self.shell.run_cmdline('/time_server/server_hostname reset')
-        self.shell.run_cmdline('/ceph_cluster/roles/admin rm node1.ceph.com')
-        self.shell.run_cmdline('/ceph_cluster/minions rm node2.ceph.com')
-        self.shell.run_cmdline('/ceph_cluster/minions rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/roles/admin remove node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions remove node2.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions remove node1.ceph.com')
 
     def test_import(self):
         self.fs.create_file('/config.json', contents=json.dumps({
@@ -219,9 +219,9 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:time_server:server_host'), 'server1')
 
         self.shell.run_cmdline('/time_server/server_hostname reset')
-        self.shell.run_cmdline('/ceph_cluster/roles/admin rm node1.ceph.com')
-        self.shell.run_cmdline('/ceph_cluster/minions rm node2.ceph.com')
-        self.shell.run_cmdline('/ceph_cluster/minions rm node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/roles/admin remove node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions remove node2.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/minions remove node1.ceph.com')
         self.fs.remove('/config.json')
 
     def test_import_invalid_host(self):


### PR DESCRIPTION
ATM we are mixing `rm` and `remove` commands, e.g.:

```
/time_server/external_servers> cd /time_server/external_servers
/time_server/external_servers> remove 0.pt.pool.ntp.org
Value removed.


/time_server/external_servers> cd /ceph_cluster/minions/
/ceph_cluster/minions> rm node3.octopus.com
1 minion removed.
```

This PR renames all `rm` commands to `remove` for consistency.

