### PR TITLE
Jenkinsfile.integration: Fix check for empty CHANGE_ID

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -4,7 +4,7 @@
 def jenkins_slave_base='storage-compute'
 
 def get_ceph_salt_git_branch(change_id) {
-    if (change_id.isEmpty()) {
+    if (!change_id || change_id.isEmpty()) {
         return "master"
     } else {
         return "origin/pr-merged/" + String.valueOf(change_id)


### PR DESCRIPTION
Commit a32ccf920fbc059c added a check for an emtpy CHANGE_ID. That
check is wrong. When no CHANGE_ID is set, the variable is null. So
check for that.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>