### PR TITLE
Advanced settings for "cephadm bootstrap"

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
@@ -42,7 +42,11 @@ run cephadm bootstrap:
                 --skip-monitoring-stack \
                 --skip-prepare-host \
                 --skip-pull \
-                --skip-ssh > /var/log/ceph/cephadm.log 2>&1
+                --skip-ssh \
+{%- for arg, value in pillar['ceph-salt'].get('bootstrap_arguments', {}).items() %}
+                --{{ arg }} {{ value if value is not none else '' }} \
+{%- endfor %}
+                > /var/log/ceph/cephadm.log 2>&1
     - env:
       - NOTIFY_SOCKET: ''
     - creates:

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -133,6 +133,24 @@ class ConfigShellTest(SaltMockTestCase):
                                       }
                                   ])
 
+    def test_cephadm_advanced_fsid(self):
+        self.assertDictOption('/cephadm_bootstrap/advanced',
+                              'ceph-salt:bootstrap_arguments',
+                              'fsid',
+                              '8726cb9c-75d8-11ea-924c-001a4aab830c')
+
+    def test_cephadm_advanced_mon_id(self):
+        self.assertDictOption('/cephadm_bootstrap/advanced',
+                              'ceph-salt:bootstrap_arguments',
+                              'mon-id',
+                              'a')
+
+    def test_cephadm_advanced_mgr_id(self):
+        self.assertDictOption('/cephadm_bootstrap/advanced',
+                              'ceph-salt:bootstrap_arguments',
+                              'mgr-id',
+                              'y')
+
     def test_cephadm_bootstrap_ceph_conf(self):
         self.assertConfigOption('/cephadm_bootstrap/ceph_conf',
                                 'ceph-salt:bootstrap_ceph_conf')
@@ -316,6 +334,15 @@ class ConfigShellTest(SaltMockTestCase):
         self.shell.run_cmdline('{} reset'.format(path))
         self.assertInSysOut('Value reset.')
         self.assertEqual(PillarManager.get(pillar_key), None)
+
+    def assertDictOption(self, path, pillar_key, parameter, value):
+        self.shell.run_cmdline('{} set "{}" "{}"'.format(path, parameter, value))
+        self.assertInSysOut('Parameter set.')
+        self.assertEqual(PillarManager.get('{}:{}'.format(pillar_key, parameter)), value)
+
+        self.shell.run_cmdline('{} remove {}'.format(path, parameter))
+        self.assertInSysOut('Parameter removed.')
+        self.assertEqual(PillarManager.get('{}:{}'.format(pillar_key, parameter)), None)
 
     def assertListOption(self, path, pillar_key, values):
         for value in values:


### PR DESCRIPTION
It's now possible to specify `fsid`, `mgr-id` and `mon-id` bootstrap options.

![Screenshot from 2020-04-07 15-26-14](https://user-images.githubusercontent.com/14297426/78681051-282aed80-78e4-11ea-9b39-b8d50c62b189.png)

Fixes: https://github.com/ceph/ceph-salt/issues/163

Signed-off-by: Ricardo Marques <rimarques@suse.com>
