### PR TITLE
Skip monitoring stack on bootstrap

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
@@ -38,6 +38,7 @@ run cephadm bootstrap:
                 --initial-dashboard-user {{ dashboard_username }} \
                 --output-keyring /etc/ceph/ceph.client.admin.keyring \
                 --output-config /etc/ceph/ceph.conf \
+                --skip-monitoring-stack \
                 --skip-prepare-host \
                 --skip-pull \
                 --skip-ssh > /var/log/ceph/cephadm.log 2>&1


### PR DESCRIPTION
ceph-salt should not install the whole monitoring stack on the bootstrap minion.

Fixes: https://github.com/ceph/ceph-salt/issues/128

Signed-off-by: Ricardo Marques <rimarques@suse.com>