### PR TITLE
Remove "disable cephadm bootstrap" functionality

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/init.sls
@@ -9,12 +9,10 @@ include:
     - .time
     - .cephtools
     - .provision-end
-{% if pillar['ceph-salt'].get('bootstrap_enabled', True) %}
     - .cephbootstrap
     - .find-admin-host
     - .cephorch
     - .ceph-admin
-{% endif %}
     - .cleanup
 
 {% else %}

--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -234,37 +234,6 @@ class SshPublicKeyHandler(PillarHandler):
             return str(ex), False
 
 
-class FlagGroupPillarHandler(OptionHandler):
-    def __init__(self, pillar_path, default):
-        self.pillar_path = pillar_path
-        self.default = default
-
-    def commands_map(self):
-        return {
-            'enable': self.enable,
-            'disable': self.disable,
-            'reset': self.reset
-        }
-
-    def enable(self):
-        PillarManager.set(self.pillar_path, True)
-        PP.pl_green('Enabled.')
-
-    def disable(self):
-        PillarManager.set(self.pillar_path, False)
-        PP.pl_green('Disabled.')
-
-    def reset(self):
-        PillarManager.reset(self.pillar_path)
-        PP.pl_green('Value reset.')
-
-    def value(self):
-        val = PillarManager.get(self.pillar_path)
-        if val is None:
-            val = self.default
-        return ("enabled", True) if val else ("disabled", True)
-
-
 class TimeServerGroupHandler(OptionHandler):
     def commands_map(self):
         return {
@@ -437,7 +406,6 @@ CEPH_SALT_OPTIONS = {
                 =========================================
                 Options to control the Ceph cluster bootstrap
                 ''',
-        'handler': FlagGroupPillarHandler('ceph-salt:bootstrap_enabled', True),
         'options': {
             'ceph_conf': {
                 'type': 'conf',

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -14,11 +14,11 @@ def validate_config(host_ls):
         bootstrap_minion_short_name = bootstrap_minion.split('.', 1)[0]
         if bootstrap_minion_short_name not in admin_nodes:
             return "Bootstrap minion must be 'Admin'"
-    bootstrap_mon_ip = PillarManager.get('ceph-salt:bootstrap_mon_ip')
-    if not bootstrap_mon_ip:
-        return "No bootstrap Mon IP specified in config"
-    if bootstrap_mon_ip in ['127.0.0.1', '::1']:
-        return 'Mon IP cannot be the loopback interface IP'
+        bootstrap_mon_ip = PillarManager.get('ceph-salt:bootstrap_mon_ip')
+        if not bootstrap_mon_ip:
+            return "No bootstrap Mon IP specified in config"
+        if bootstrap_mon_ip in ['127.0.0.1', '::1']:
+            return 'Mon IP cannot be the loopback interface IP'
     time_server_host = PillarManager.get('ceph-salt:time_server:server_host')
     if not time_server_host:
         return 'No time server host specified in config'

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -133,10 +133,6 @@ class ConfigShellTest(SaltMockTestCase):
                                       }
                                   ])
 
-    def test_cephadm_bootstrap(self):
-        self.assertFlagOption('/cephadm_bootstrap',
-                              'ceph-salt:bootstrap_enabled')
-
     def test_cephadm_bootstrap_ceph_conf(self):
         self.assertConfigOption('/cephadm_bootstrap/ceph_conf',
                                 'ceph-salt:bootstrap_ceph_conf')


### PR DESCRIPTION
Being able to disable bootstrap is a useless feature that adds unnecessary complexity to `ceph-salt`.

Fixes: https://github.com/ceph/ceph-salt/issues/181

Signed-off-by: Ricardo Marques <rimarques@suse.com>