### PR TITLE
Require Salt >= 3000

### DIFF
--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -46,12 +46,12 @@ Requires:       python3-configshell-fb >= 1.1
 Requires:       python3-pycryptodomex >= 3.4.6
 Requires:       python3-PyYAML >= 5.1.2
 Requires:       python3-setuptools
-Requires:       python3-salt >= 2019.2.0
+Requires:       python3-salt >= 3000
 Requires:       python3-curses
 %endif
 
 Requires:       ceph-salt-formula
-Requires:       salt-master >= 2019.2.0
+Requires:       salt-master >= 3000
 Requires:       procps
 
 

--- a/ceph_salt/salt_event.py
+++ b/ceph_salt/salt_event.py
@@ -5,7 +5,7 @@ import threading
 
 import salt.config
 import salt.utils.event
-from tornado.ioloop import IOLoop
+from salt.ext.tornado.ioloop import IOLoop
 
 # pylint: disable=C0103
 logger = logging.getLogger(__name__)

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,7 @@ install_requires =
     configshell-fb >= 1.1
     pycryptodomex >= 3.4.6
     PyYAML >= 5.1.2
-    salt >= 2019.2.0
-    tornado >= 4.2.1, < 5.0
+    salt >= 3000
 
 packages =
     ceph_salt


### PR DESCRIPTION
By forcing Salt >= 3000 we no longer require `python3-tornado`.

Signed-off-by: Ricardo Marques <rimarques@suse.com>