### PR TITLE
Fix `status` error when no minions are specified

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -1114,6 +1114,8 @@ base:
 
 def count_hosts(host_ls):
     all_nodes = PillarManager.get('ceph-salt:minions:all')
+    if all_nodes is None:
+        all_nodes = []
     deployed = []
     not_managed = []
     for host in host_ls:


### PR DESCRIPTION
Fix the following error that happens when running `ceph-salt status` without minions on config:

```
master:~ # ceph-salt status
No minions matched the target. No command was sent, no jid was assigned.
Traceback (most recent call last):
  File "/usr/bin/ceph-salt", line 11, in <module>
    load_entry_point('ceph-salt==15.2.1+1587155350.g440cd72', 'console_scripts', 'ceph-salt')()
  File "/usr/lib/python3.6/site-packages/ceph_salt/__init__.py", line 55, in ceph_salt_main
    cli(prog_name='ceph-salt')
  File "/usr/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/ceph_salt/__init__.py", line 103, in status
    if not run_status():
  File "/usr/lib/python3.6/site-packages/ceph_salt/config_shell.py", line 1133, in run_status
    ceph_salt_nodes, deployed_nodes, not_managed_nodes = count_hosts(host_ls)
  File "/usr/lib/python3.6/site-packages/ceph_salt/config_shell.py", line 1124, in count_hosts
    return (len(all_nodes), len(deployed), len(not_managed))
TypeError: object of type 'NoneType' has no len()

```

Signed-off-by: Ricardo Marques <rimarques@suse.com>