### PR TITLE
[WIP] Do not install "ceph-common"

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_orch.py
+++ b/ceph-salt-formula/salt/_modules/ceph_orch.py
@@ -2,18 +2,18 @@
 import json
 
 def configured():
-    ret = __salt__['cmd.run_all']("sh -c 'type ceph'")
+    ret = __salt__['cmd.run_all']("sh -c 'type cephadm'")
     if ret['retcode'] != 0:
         return False
     if not __salt__['file.file_exists']("/etc/ceph/ceph.conf"):
         return False
     if not __salt__['file.file_exists']("/etc/ceph/ceph.client.admin.keyring"):
         return False
-    ret = __salt__['cmd.run_all']("ceph orch status")
+    ret = __salt__['cmd.run_all']("cephadm shell -- ceph orch status")
     if ret['retcode'] != 0:
         return False
     return True
 
 def host_ls():
-    ret = __salt__['cmd.run']("ceph orch host ls --format=json")
+    ret = __salt__['cmd.run']("cephadm shell -- ceph orch host ls --format=json")
     return json.loads(ret)

--- a/ceph-salt-formula/salt/_states/ceph_orch.py
+++ b/ceph-salt-formula/salt/_states/ceph_orch.py
@@ -39,7 +39,8 @@ def add_host(name, host):
     admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
     cmd_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
                                       "-i /tmp/ceph-salt-ssh-id_rsa root@{} "
-                                      "'ceph orch host add {}'".format(admin_host, host))
+                                      "'cephadm shell -- ceph orch host add {}'".format(
+                                          admin_host, host))
     if cmd_ret['retcode'] == 0:
         ret['result'] = True
     return ret

--- a/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
@@ -57,7 +57,7 @@ run cephadm bootstrap:
 set ceph-dashboard password:
   cmd.run:
     - name: |
-        ceph dashboard ac-user-set-password --force-password admin {{ dashboard_password }}
+        cephadm shell -- ceph dashboard ac-user-set-password --force-password admin {{ dashboard_password }}
     - onchanges:
       - cmd: run cephadm bootstrap
     - failhard: True
@@ -68,10 +68,10 @@ set ceph-dashboard password:
 configure ssh orchestrator:
   cmd.run:
     - name: |
-        ceph config-key set mgr/cephadm/ssh_identity_key -i /tmp/ceph-salt-ssh-id_rsa
-        ceph config-key set mgr/cephadm/ssh_identity_pub -i /tmp/ceph-salt-ssh-id_rsa.pub
-        ceph mgr module enable cephadm && \
-        ceph orch set backend cephadm
+        cephadm shell -- ceph config-key set mgr/cephadm/ssh_identity_key -i /tmp/ceph-salt-ssh-id_rsa
+        cephadm shell -- ceph config-key set mgr/cephadm/ssh_identity_pub -i /tmp/ceph-salt-ssh-id_rsa.pub
+        cephadm shell -- ceph mgr module enable cephadm && \
+        cephadm shell -- ceph orch set backend cephadm
     - onchanges:
       - cmd: run cephadm bootstrap
     - failhard: True

--- a/ceph-salt-formula/salt/ceph-salt/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephtools.sls
@@ -2,28 +2,31 @@
 
 {{ macros.begin_stage('Prepare to bootstrap the Ceph cluster') }}
 
-{{ macros.begin_step('Install cephadm and other packages') }}
+{{ macros.begin_step('Install cephadm package') }}
 
 install cephadm:
   pkg.installed:
     - pkgs:
         - cephadm
-{% if 'admin' in grains['ceph-salt']['roles'] %}
-        - ceph-common
-{% endif %}
     - failhard: True
 
-{% if grains['id'] == pillar['ceph-salt']['bootstrap_minion'] %}
 /var/log/ceph:
   file.directory:
-    - user: ceph
-    - group: ceph
+    - user: root
+    - group: root
     - mode: '0770'
     - makedirs: True
     - failhard: True
-{% endif %}
 
-{{ macros.end_step('Install cephadm and other packages') }}
+/etc/ceph/ceph:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: '0770'
+    - makedirs: True
+    - failhard: True
+
+{{ macros.end_step('Install cephadm package') }}
 
 {{ macros.begin_step('Run "cephadm check-host"') }}
 


### PR DESCRIPTION
**Blocked by https://github.com/ceph/ceph/pull/34773**

---

`cephadm shell -- ceph ....` should be used instead of `ceph`


Fixes: https://github.com/ceph/ceph-salt/issues/120

Signed-off-by: Ricardo Marques <rimarques@suse.com>