### PR TITLE
[WIP] Ceph config should not be managed by 'ceph-salt'

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ autocomplete and glob expressions:
 /ceph_cluster/minions add *
 ```
 
-Then we must specify which minions will have "ceph.conf" and "keyring" installed:
+Then we must specify which minions will have "keyring" installed:
 
 ```
 /ceph_cluster/roles/admin add *

--- a/ceph-salt-formula/salt/_modules/ceph_orch.py
+++ b/ceph-salt-formula/salt/_modules/ceph_orch.py
@@ -5,8 +5,6 @@ def configured():
     ret = __salt__['cmd.run_all']("sh -c 'type ceph'")
     if ret['retcode'] != 0:
         return False
-    if not __salt__['file.file_exists']("/etc/ceph/ceph.conf"):
-        return False
     if not __salt__['file.file_exists']("/etc/ceph/ceph.client.admin.keyring"):
         return False
     ret = __salt__['cmd.run_all']("ceph orch status")

--- a/ceph-salt-formula/salt/_states/ceph_orch.py
+++ b/ceph-salt-formula/salt/_states/ceph_orch.py
@@ -45,12 +45,12 @@ def add_host(name, host):
     return ret
 
 
-def copy_ceph_conf_and_keyring(name):
+def copy_keyring(name):
     ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
     admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
     cmd_ret = __salt__['cmd.run_all']("scp -o StrictHostKeyChecking=no "
                                       "-i /tmp/ceph-salt-ssh-id_rsa "
-                                      "root@{}:/etc/ceph/{{ceph.conf,ceph.client.admin.keyring}} "
+                                      "root@{}:/etc/ceph/ceph.client.admin.keyring "
                                       "/etc/ceph/".format(admin_host))
     if cmd_ret['retcode'] == 0:
         ret['result'] = True

--- a/ceph-salt-formula/salt/ceph-salt/ceph-admin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/ceph-admin.sls
@@ -2,10 +2,10 @@
 
 {% if 'admin' in grains['ceph-salt']['roles'] %}
 
-{{ macros.begin_stage('Ensure ceph.conf and keyring are present') }}
-copy ceph.conf and keyring from an admin node:
-  ceph_orch.copy_ceph_conf_and_keyring:
+{{ macros.begin_stage('Ensure keyring is present') }}
+copy keyring from an admin node:
+  ceph_orch.copy_keyring:
     - failhard: True
-{{ macros.end_stage('Ensure ceph.conf and keyring are present') }}
+{{ macros.end_stage('Ensure keyring is present') }}
 
 {% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
@@ -38,7 +38,6 @@ run cephadm bootstrap:
                 --config /tmp/bootstrap-ceph.conf \
                 --initial-dashboard-user {{ dashboard_username }} \
                 --output-keyring /etc/ceph/ceph.client.admin.keyring \
-                --output-config /etc/ceph/ceph.conf \
                 --skip-monitoring-stack \
                 --skip-prepare-host \
                 --skip-pull \
@@ -50,7 +49,6 @@ run cephadm bootstrap:
     - env:
       - NOTIFY_SOCKET: ''
     - creates:
-      - /etc/ceph/ceph.conf
       - /etc/ceph/ceph.client.admin.keyring
     - failhard: True
 


### PR DESCRIPTION
**After ceph/ceph#35576 is backported (ceph/ceph#35898)**
~~**After https://github.com/ceph/ceph/pull/34728**~~
~~**After https://tracker.ceph.com/issues/45378**~~

---

`ceph-salt` should not store and manage `ceph.conf` file.

Fixes: https://github.com/ceph/ceph-salt/issues/199

Signed-off-by: Ricardo Marques <rimarques@suse.com>