### PR TITLE
Wait for admin should fail if any admin failed

### DIFF
--- a/ceph-salt-formula/salt/_states/ceph_orch.py
+++ b/ceph-salt-formula/salt/_states/ceph_orch.py
@@ -16,6 +16,10 @@ def wait_for_admin_host(name, timeout=1800):
         time.sleep(5)
         admin_hosts = __pillar__['ceph-salt']['minions']['admin']
         for admin_host in admin_hosts:
+            failed = __salt__['ceph_salt.get_remote_grain'](admin_host, 'ceph-salt:execution:failed')
+            if failed:
+                ret['comment'] = 'One or more admin minions failed.'
+                return ret
             provisioned = __salt__['ceph_salt.get_remote_grain'](admin_host,
                                                                 'ceph-salt:execution:provisioned')
             if provisioned:


### PR DESCRIPTION
The `wait_for_admin_host` state should fail If any `admin` minion failed execution.

Example:
---

1) Both `/system_update/packages` and `/system_update/reboot` are enabled
2) All `minions` rebooted automatically, but `master` must be rebooted manually so the execution fail on `master`
3) Because `master` failed, then `bootstrap minion` will fail with `"One or more minions failed."` (while waiting for all other minions to be provisioned)
4) Since `boostrap minion` failed, all other minions that are waiting an an `admin` node should fail instead of waiting until the timeout is reached.

This PR implements `4)`.

![Screenshot from 2020-04-29 15-59-29](https://user-images.githubusercontent.com/14297426/80612859-6ffcea80-8a34-11ea-8e5b-8a3e4534630e.png)


Fixes: https://github.com/ceph/ceph-salt/issues/196

Signed-off-by: Ricardo Marques <rimarques@suse.com>