### PR TITLE
Store minion_id in pillar instead of hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ This repository contains two components:
 
 # Setup
 
-In order to use `ceph-salt`, you need a working Salt cluster.
+In order to use `ceph-salt`, you need a working Salt cluster and minion IDs
+must be resolvable to IP addresses (e.g. `host <minion_id>`).
 
 Now, install `ceph-salt` on your Salt Master from the openSUSE
 repositories:

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -6,13 +6,12 @@ def validate_config(host_ls):
     :return: Error message if config is invalid, otherwise "None"
     """
     bootstrap_minion = PillarManager.get('ceph-salt:bootstrap_minion')
-    admin_nodes = PillarManager.get('ceph-salt:minions:admin')
+    admin_minions = PillarManager.get('ceph-salt:minions:admin')
     deployed = len(host_ls) > 0
     if not deployed:
         if not bootstrap_minion:
             return "No bootstrap minion specified in config"
-        bootstrap_minion_short_name = bootstrap_minion.split('.', 1)[0]
-        if bootstrap_minion_short_name not in admin_nodes:
+        if bootstrap_minion not in admin_minions:
             return "Bootstrap minion must be 'Admin'"
         bootstrap_mon_ip = PillarManager.get('ceph-salt:bootstrap_mon_ip')
         if not bootstrap_mon_ip:
@@ -25,9 +24,9 @@ def validate_config(host_ls):
     time_server_subnet = PillarManager.get('ceph-salt:time_server:subnet')
     if not time_server_subnet:
         return 'No time server subnet specified in config'
-    all_nodes = PillarManager.get('ceph-salt:minions:all')
-    for admin_node in admin_nodes:
-        if admin_node not in all_nodes:
+    all_minions = PillarManager.get('ceph-salt:minions:all')
+    for admin_minion in admin_minions:
+        if admin_minion not in all_minions:
             return "One or more Admin nodes are not cluster minions"
     ceph_container_image_path = PillarManager.get('ceph-salt:container:images:ceph')
     if not ceph_container_image_path:

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -34,7 +34,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True,
                                                           'roles': [],
                                                           'execution': {}})
-        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1.ceph.com'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
 
@@ -54,7 +54,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.shell.run_cmdline('/ceph_cluster/minions remove node1.ceph.com')
         self.assertInSysOut("Cannot remove host 'node1.ceph.com' because it has roles defined: "
                             "['admin', 'bootstrap']")
-        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1.ceph.com'])
 
         self.shell.run_cmdline('/ceph_cluster/roles/admin remove node1.ceph.com')
         self.shell.run_cmdline('/ceph_cluster/roles/bootstrap reset')
@@ -69,8 +69,8 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True,
                                                           'roles': ['admin'],
                                                           'execution': {}})
-        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
-        self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1.ceph.com'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), ['node1.ceph.com'])
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
 
         self.shell.run_cmdline('/ceph_cluster/roles/admin remove node1.ceph.com')
@@ -78,7 +78,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True,
                                                           'roles': [],
                                                           'execution': {}})
-        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1.ceph.com'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
 
@@ -95,7 +95,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True,
                                                           'roles': [],
                                                           'execution': {}})
-        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1.ceph.com'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), 'node1.ceph.com')
 
@@ -104,7 +104,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertGrains('node1.ceph.com', 'ceph-salt', {'member': True,
                                                           'roles': [],
                                                           'execution': {}})
-        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1.ceph.com'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), [])
         self.assertEqual(PillarManager.get('ceph-salt:bootstrap_minion'), None)
 
@@ -225,8 +225,8 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertTrue(run_export(False))
         self.assertJsonInSysOut({
             'minions': {
-                'all': ['node1', 'node2'],
-                'admin': ['node1']
+                'all': ['node1.ceph.com', 'node2.ceph.com'],
+                'admin': ['node1.ceph.com']
             },
             'time_server': {
                 'server_host': 'node1.ceph.com',
@@ -242,8 +242,8 @@ class ConfigShellTest(SaltMockTestCase):
     def test_import(self):
         self.fs.create_file('/config.json', contents=json.dumps({
             'minions': {
-                'all': ['node1', 'node2'],
-                'admin': ['node1']
+                'all': ['node1.ceph.com', 'node2.ceph.com'],
+                'admin': ['node1.ceph.com']
             },
             'time_server': {
                 'server_host': 'node1.ceph.com',
@@ -259,8 +259,9 @@ class ConfigShellTest(SaltMockTestCase):
                           'ceph-salt', {'member': True,
                                         'roles': [],
                                         'execution': {}})
-        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1', 'node2'])
-        self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), ['node1'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1.ceph.com',
+                                                                      'node2.ceph.com'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), ['node1.ceph.com'])
         self.assertIsNone(PillarManager.get('ceph-salt:bootstrap_minion'))
         self.assertEqual(PillarManager.get('ceph-salt:time_server:server_host'), 'node1.ceph.com')
         self.assertEqual(PillarManager.get('ceph-salt:time_server:subnet'), '10.20.188.0/24')
@@ -276,12 +277,12 @@ class ConfigShellTest(SaltMockTestCase):
     def test_import_invalid_host(self):
         self.fs.create_file('/config.json', contents=json.dumps({
             'minions': {
-                'all': ['node1', 'node2', 'node9'],
-                'admin': ['node1']
+                'all': ['node1.ceph.com', 'node2.ceph.com', 'node9.ceph.com'],
+                'admin': ['node1.ceph.com']
             }}))
 
         self.assertFalse(run_import("/config.json"))
-        self.assertInSysOut("Cannot find host 'node9'")
+        self.assertInSysOut("Cannot find minion 'node9.ceph.com'")
 
         self.fs.remove('/config.json')
 

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -42,7 +42,7 @@ class ValidateConfigTest(SaltMockTestCase):
 
     def test_admin_not_cluster_minion(self):
         PillarManager.set('ceph-salt:bootstrap_minion', 'node3.ceph.com')
-        PillarManager.set('ceph-salt:minions:admin', ['node3'])
+        PillarManager.set('ceph-salt:minions:admin', ['node3.ceph.com'])
         self.assertEqual(validate_config([]), "One or more Admin nodes are not cluster minions")
 
     def test_no_ceph_container_image_path(self):
@@ -58,6 +58,6 @@ class ValidateConfigTest(SaltMockTestCase):
         PillarManager.set('ceph-salt:bootstrap_mon_ip', '10.20.188.201')
         PillarManager.set('ceph-salt:time_server:server_host', 'node1.ceph.com')
         PillarManager.set('ceph-salt:time_server:subnet', '10.20.188.0/24')
-        PillarManager.set('ceph-salt:minions:all', ['node1', 'node2'])
-        PillarManager.set('ceph-salt:minions:admin', ['node1'])
+        PillarManager.set('ceph-salt:minions:all', ['node1.ceph.com', 'node2.ceph.com'])
+        PillarManager.set('ceph-salt:minions:admin', ['node1.ceph.com'])
         PillarManager.set('ceph-salt:container:images:ceph', 'docker.io/ceph/daemon-base:latest')


### PR DESCRIPTION
With this PR we will always store the `minion_id` in pillar, instead of the `hostname`.

Also, we are now using the `host` grain do get the minion hostname used on `cephadm orch` commands, instead of relying on `minion_id.split('.', 1)[0]` to infer that.

Note that minion ID must resolve to an IP address (see README).

Fixes: https://github.com/ceph/ceph-salt/issues/210

Signed-off-by: Ricardo Marques <rimarques@suse.com>