### PR TITLE
Do not modify registries.conf when not needed

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/container.sls
+++ b/ceph-salt-formula/salt/ceph-salt/container.sls
@@ -4,6 +4,8 @@
 
 {{ macros.begin_step('Configure registries') }}
 
+{% with registries = pillar['ceph-salt'].get('container', {}).get('registries', []) %}
+  {% if registries|length > 0 %}
 /etc/containers/registries.conf:
   file.managed:
     - source:
@@ -14,6 +16,10 @@
     - mode: '0644'
     - backup: minion
     - failhard: True
+    - defaults:
+        registries: {{ registries }}
+  {% endif %}
+{% endwith %}
 
 {{ macros.end_step('Configure registries') }}
 

--- a/ceph-salt-formula/salt/ceph-salt/files/registries.conf.j2
+++ b/ceph-salt-formula/salt/ceph-salt/files/registries.conf.j2
@@ -1,4 +1,3 @@
-{% set registries = pillar['ceph-salt'].get('container', {}).get('registries', []) -%}
 # {% include "ceph-salt/files/managed-header.txt.j2" ignore missing %}
 # For more information on this configuration file, see containers-registries.conf(5)
 


### PR DESCRIPTION
When no container/registries salt pillar is set, do not modify
/etc/containers/registries.conf . That way, users can modify the file
manually and it won't be overwritten when not configured within
ceph-salt.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>