### PR TITLE
Log warn when public IP is loopback IP ('127.0.0.1')

### DIFF
--- a/ceph_salt/core.py
+++ b/ceph_salt/core.py
@@ -52,6 +52,9 @@ class CephNode:
                 if addr != '127.0.0.1':
                     public_ip = addr
                     break
+        if public_ip == '127.0.0.1':
+            logger.warning("'%s' public IP is the loopback interface IP ('127.0.0.1')",
+                           self.minion_id)
         self.public_ip = public_ip
         result = SaltClient.local_cmd(self.minion_id, 'network.subnets')
         self.subnets = result[self.minion_id]


### PR DESCRIPTION
```
# grep 'WARNING' /var/log/ceph-salt.log
2020-05-06 15:07:15,346 [WARNING] [ceph_salt.core] 'master.octopus.com' public IP is the loopback interface IP ('127.0.0.1')
```

Fixes: https://github.com/ceph/ceph-salt/issues/183

Signed-off-by: Ricardo Marques <rimarques@suse.com>