### PR TITLE
Default values are now persisted in pillar data

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
@@ -28,7 +28,7 @@ wait for other minions:
 
 {{ macros.begin_step('Run "cephadm bootstrap"') }}
 
-{% set dashboard_username = pillar['ceph-salt'].get('dashboard', {'username': 'admin'}).get('username', 'admin') %}
+{% set dashboard_username = pillar['ceph-salt']['dashboard']['username'] %}
 
 run cephadm bootstrap:
   cmd.run:

--- a/ceph-salt-formula/salt/ceph-salt/software.sls
+++ b/ceph-salt-formula/salt/ceph-salt/software.sls
@@ -10,7 +10,7 @@ install required packages:
       - podman
     - failhard: True
 
-{% if pillar['ceph-salt'].get('updates', {}).get('enabled', True) %}
+{% if pillar['ceph-salt']['updates']['enabled'] %}
 
 {{ macros.begin_step('Update all packages') }}
 
@@ -30,7 +30,7 @@ updates disabled:
 
 {{ macros.end_stage('Install and update required packages') }}
 
-{% if pillar['ceph-salt'].get('updates', {}).get('reboot', True) %}
+{% if pillar['ceph-salt']['updates']['reboot'] %}
 
 reboot:
    ceph_salt.reboot_if_needed:

--- a/ceph-salt-formula/salt/ceph-salt/time-prep.sls
+++ b/ceph-salt-formula/salt/ceph-salt/time-prep.sls
@@ -1,4 +1,4 @@
-{% if pillar['ceph-salt']['time_server'].get('enabled', True) %}
+{% if pillar['ceph-salt']['time_server']['enabled'] %}
 
 {% import 'macros.yml' as macros %}
 
@@ -47,4 +47,3 @@ start chronyd:
 
 prevent empty time-prep:
   test.nop
-

--- a/ceph-salt-formula/salt/ceph-salt/time-sync.sls
+++ b/ceph-salt-formula/salt/ceph-salt/time-sync.sls
@@ -1,4 +1,4 @@
-{% if pillar['ceph-salt']['time_server'].get('enabled', True) %}
+{% if pillar['ceph-salt']['time_server']['enabled'] %}
 {% set time_server = pillar['ceph-salt']['time_server']['server_host'] %}
 {% set time_server_is_minion = time_server in pillar['ceph-salt']['minions']['all'] %}
 
@@ -60,4 +60,3 @@ delete clock sync script:
 
 prevent empty time-sync:
   test.nop
-

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -14,12 +14,25 @@ def validate_config(host_ls):
             return "No bootstrap minion specified in config"
         if bootstrap_minion not in admin_minions:
             return "Bootstrap minion must be 'Admin'"
+        dashboard_username = PillarManager.get('ceph-salt:dashboard:username')
+        if not dashboard_username:
+            return "No dashboard username specified in config"
         bootstrap_mon_ip = PillarManager.get('ceph-salt:bootstrap_mon_ip')
         if not bootstrap_mon_ip:
             return "No bootstrap Mon IP specified in config"
         if bootstrap_mon_ip in ['127.0.0.1', '::1']:
             return 'Mon IP cannot be the loopback interface IP'
-    time_server_enabled = PillarManager.get('ceph-salt:time_server:enabled', True)
+
+    # system_update
+    if not isinstance(PillarManager.get('ceph-salt:updates:enabled'), bool):
+        return "'ceph-salt:updates:enabled' must be of type Boolean"
+    if not isinstance(PillarManager.get('ceph-salt:updates:reboot'), bool):
+        return "'ceph-salt:updates:reboot' must be of type Boolean"
+
+    # time_server
+    time_server_enabled = PillarManager.get('ceph-salt:time_server:enabled')
+    if not isinstance(time_server_enabled, bool):
+        return "'ceph-salt:time_server:enabled' must be of type Boolean"
     if time_server_enabled:
         time_server_host = PillarManager.get('ceph-salt:time_server:server_host')
         if not time_server_host:

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -32,6 +32,23 @@ class ValidateConfigTest(SaltMockTestCase):
         PillarManager.set('ceph-salt:bootstrap_mon_ip', '127.0.0.1')
         self.assertEqual(validate_config([]), "Mon IP cannot be the loopback interface IP")
 
+    def test_no_dashboard_username(self):
+        PillarManager.reset('ceph-salt:dashboard:username')
+        self.assertEqual(validate_config([]), "No dashboard username specified in config")
+
+    def test_updates_enabled_not_set(self):
+        PillarManager.reset('ceph-salt:updates:enabled')
+        self.assertEqual(validate_config([]), "'ceph-salt:updates:enabled' must be of type Boolean")
+
+    def test_updates_reboot_not_set(self):
+        PillarManager.reset('ceph-salt:updates:reboot')
+        self.assertEqual(validate_config([]), "'ceph-salt:updates:reboot' must be of type Boolean")
+
+    def test_time_server_enabled_not_set(self):
+        PillarManager.reset('ceph-salt:time_server:enabled')
+        self.assertEqual(validate_config([]),
+                         "'ceph-salt:time_server:enabled' must be of type Boolean")
+
     def test_no_time_server_host(self):
         PillarManager.reset('ceph-salt:time_server:server_host')
         self.assertEqual(validate_config([]), "No time server host specified in config")
@@ -72,6 +89,7 @@ class ValidateConfigTest(SaltMockTestCase):
 
     @classmethod
     def create_valid_config(cls):
+        PillarManager.set('ceph-salt:dashboard:username', 'admin')
         PillarManager.set('ceph-salt:bootstrap_minion', 'node1.ceph.com')
         PillarManager.set('ceph-salt:bootstrap_mon_ip', '10.20.188.201')
         PillarManager.set('ceph-salt:time_server:enabled', True)
@@ -80,4 +98,6 @@ class ValidateConfigTest(SaltMockTestCase):
         PillarManager.set('ceph-salt:time_server:subnet', '10.20.188.0/24')
         PillarManager.set('ceph-salt:minions:all', ['node1.ceph.com', 'node2.ceph.com'])
         PillarManager.set('ceph-salt:minions:admin', ['node1.ceph.com'])
+        PillarManager.set('ceph-salt:updates:enabled', True)
+        PillarManager.set('ceph-salt:updates:reboot', True)
         PillarManager.set('ceph-salt:container:images:ceph', 'docker.io/ceph/daemon-base:latest')


### PR DESCRIPTION
With this PR, default pillar values will be persisted when `ceph-salt config` is executed for the first time:

```
master:~ # cat /srv/pillar/ceph-salt.sls
ceph-salt: {}

master:~ # ceph-salt config
/> exit

master:~ # cat /srv/pillar/ceph-salt.sls
ceph-salt:
  dashboard:
    username: admin
  updates:
    enabled: true
    reboot: true
```

This PR resolves the following issues:

1) Default values are no longer duplicated in `ceph-salt` and `ceph-salt-formula`, see https://github.com/ceph/ceph-salt/issues/60

2) When `reset` command is used, default value is writen to pillar data (instead of removed), see https://github.com/ceph/ceph-salt/issues/177

3) This new approach will allow us to generate a random dashboard password in `ceph-salt`, in order to fix https://github.com/ceph/ceph-salt/issues/192

Fixes: https://github.com/ceph/ceph-salt/issues/60
Fixes: https://github.com/ceph/ceph-salt/issues/177

Signed-off-by: Ricardo Marques <rimarques@suse.com>