### PR TITLE
Unable to see dashboard password

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -3,6 +3,8 @@ import itertools
 import logging
 import fnmatch
 import json
+import random
+import string
 
 
 from pyparsing import alphanums, OneOrMore, Optional, Regex, Suppress, Word, QuotedString
@@ -311,6 +313,12 @@ class TimeSubnetHandler(PillarHandler):
         return []
 
 
+def generate_password():
+    # type: () -> str
+    return ''.join(random.choice(string.ascii_lowercase + string.digits)
+                   for i in range(10))
+
+
 CEPH_SALT_OPTIONS = {
     'ceph_cluster': {
         'help': '''
@@ -442,9 +450,14 @@ CEPH_SALT_OPTIONS = {
                 'help': 'Dashboard settings',
                 'options': {
                     'password': {
-                        'default_text': 'randomly generated',
-                        'sensitive': True,
-                        'handler': PillarHandler('ceph-salt:dashboard:password')
+                        'handler': PillarHandler('ceph-salt:dashboard:password',
+                                                 generate_password())
+                    },
+                    'force_password_update': {
+                        'type': 'flag',
+                        'help': 'Force password change at first login',
+                        'handler': PillarHandler('ceph-salt:dashboard:password_update_required',
+                                                 True)
                     },
                     'username': {
                         'handler': PillarHandler('ceph-salt:dashboard:username', 'admin')

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -17,6 +17,11 @@ def validate_config(host_ls):
         dashboard_username = PillarManager.get('ceph-salt:dashboard:username')
         if not dashboard_username:
             return "No dashboard username specified in config"
+        dashboard_password = PillarManager.get('ceph-salt:dashboard:password')
+        if not dashboard_password:
+            return "No dashboard password specified in config"
+        if not isinstance(PillarManager.get('ceph-salt:dashboard:password_update_required'), bool):
+            return "'ceph-salt:dashboard:password_update_required' must be of type Boolean"
         bootstrap_mon_ip = PillarManager.get('ceph-salt:bootstrap_mon_ip')
         if not bootstrap_mon_ip:
             return "No bootstrap Mon IP specified in config"

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -155,10 +155,17 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertConfigOption('/cephadm_bootstrap/ceph_conf',
                                 'ceph-salt:bootstrap_ceph_conf')
 
+    def test_cephadm_bootstrap_dashboard_force_password_update(self):
+        self.assertFlagOption('/cephadm_bootstrap/dashboard/force_password_update',
+                              'ceph-salt:dashboard:password_update_required',
+                              True)
+
     def test_cephadm_bootstrap_dashboard_password(self):
+        default = PillarManager.get('ceph-salt:dashboard:password')
         self.assertValueOption('/cephadm_bootstrap/dashboard/password',
                                'ceph-salt:dashboard:password',
-                               'mypassword')
+                               'mypassword',
+                               default)
 
     def test_cephadm_bootstrap_dashboard_username(self):
         self.assertValueOption('/cephadm_bootstrap/dashboard/username',
@@ -228,7 +235,9 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertTrue(run_export(False))
         self.assertJsonInSysOut({
             'dashboard': {
-                'username': 'admin'
+                'username': 'admin',
+                'password': PillarManager.get('ceph-salt:dashboard:password'),
+                'password_update_required': True
             },
             'minions': {
                 'all': ['node1.ceph.com', 'node2.ceph.com'],

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -36,6 +36,15 @@ class ValidateConfigTest(SaltMockTestCase):
         PillarManager.reset('ceph-salt:dashboard:username')
         self.assertEqual(validate_config([]), "No dashboard username specified in config")
 
+    def test_no_dashboard_password(self):
+        PillarManager.reset('ceph-salt:dashboard:password')
+        self.assertEqual(validate_config([]), "No dashboard password specified in config")
+
+    def test_dashboard_password_update_required_not_set(self):
+        PillarManager.reset('ceph-salt:dashboard:password_update_required')
+        self.assertEqual(validate_config([]),
+                         "'ceph-salt:dashboard:password_update_required' must be of type Boolean")
+
     def test_updates_enabled_not_set(self):
         PillarManager.reset('ceph-salt:updates:enabled')
         self.assertEqual(validate_config([]), "'ceph-salt:updates:enabled' must be of type Boolean")
@@ -89,7 +98,9 @@ class ValidateConfigTest(SaltMockTestCase):
 
     @classmethod
     def create_valid_config(cls):
-        PillarManager.set('ceph-salt:dashboard:username', 'admin')
+        PillarManager.set('ceph-salt:dashboard:username', 'admin1')
+        PillarManager.set('ceph-salt:dashboard:password', 'admin2')
+        PillarManager.set('ceph-salt:dashboard:password_update_required', True)
         PillarManager.set('ceph-salt:bootstrap_minion', 'node1.ceph.com')
         PillarManager.set('ceph-salt:bootstrap_mon_ip', '10.20.188.201')
         PillarManager.set('ceph-salt:time_server:enabled', True)


### PR DESCRIPTION
~~AFTER https://github.com/ceph/ceph-salt/pull/219~~

---

With this PR:

1) Default dashboard password will be generated by `ceph-salt`, so the user can see it in `config ls`
2) User will be forced to change Dashboard password on the first login
3) Default dashboard password is no longer hidden (`***`) on `config ls` because of 2)



Fixes: https://github.com/ceph/ceph-salt/issues/192
