### PR TITLE
Fix error running `status` with empty pillar data

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -1113,7 +1113,7 @@ base:
 
 def count_hosts(host_ls):
     all_hostnames = [CephNode(minion_id).hostname for minion_id
-                     in PillarManager.get('ceph-salt:minions:all')]
+                     in PillarManager.get('ceph-salt:minions:all', [])]
     deployed = []
     not_managed = []
     for host in host_ls:


### PR DESCRIPTION
Before this PR
```
master:~ # cat /srv/pillar/ceph-salt.sls 
ceph-salt: {}

master:~ # ceph-salt status
Traceback (most recent call last):
  File "/usr/bin/ceph-salt", line 11, in <module>
    load_entry_point('ceph-salt==15.2.3', 'console_scripts', 'ceph-salt')()
  File "/usr/lib/python3.6/site-packages/ceph_salt/__init__.py", line 55, in ceph_salt_main
    cli(prog_name='ceph-salt')
  File "/usr/lib64/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib64/python3.6/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/lib64/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib64/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib64/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/ceph_salt/__init__.py", line 103, in status
    if not run_status():
  File "/usr/lib/python3.6/site-packages/ceph_salt/config_shell.py", line 1152, in run_status
    ceph_salt_nodes, deployed_nodes, not_managed_nodes = count_hosts(host_ls)
  File "/usr/lib/python3.6/site-packages/ceph_salt/config_shell.py", line 1135, in count_hosts
    in PillarManager.get('ceph-salt:minions:all')]
TypeError: 'NoneType' object is not iterable
```


After this PR
```
master:~ # cat /srv/pillar/ceph-salt.sls 
ceph-salt: {}


master:~/ceph-salt # ceph-salt status
hosts:  0/0 managed by cephadm
config: No time server host specified in config
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>