### PR TITLE
Optimize remote grain get

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -2,10 +2,20 @@
 import json
 
 def get_remote_grain(host, grain):
+    """
+    Reads remote host grain by accessing '/etc/salt/grains' file directly.
+    """
     ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
                                   "-i /tmp/ceph-salt-ssh-id_rsa root@{} "
-                                  "'salt-call grains.get --out=json --out-indent=-1 {}'".format(
-                                      host, grain))
+                                  "\"python3 - <<EOF\n"
+                                  "import json\n"
+                                  "import salt.utils.data\n"
+                                  "import yaml\n"
+                                  "with open('/etc/salt/grains') as grains_file:\n"
+                                  "    grains = yaml.full_load(grains_file)\n"
+                                  "val = salt.utils.data.traverse_dict_and_list(grains, '{}')\n"
+                                  "print(json.dumps({{'local': val}}))\n"
+                                  "EOF\"".format(host, grain))
     if ret['retcode'] != 0:
         return None
     return json.loads(ret['stdout'])['local']


### PR DESCRIPTION
Reading grain from `/etc/salt/grains` file directly is faster than using `salt-call grains.get`.

**Performance using salt-call**
```
master:~ # time salt-call grains.get ceph-salt:execution:provisioned
local:
    True
real	0m5.560s
user	0m5.133s
sys	0m0.246s
```

**Performance reading directly from file**
```
master:~ # time python3 - <<EOF
> import salt.utils.data
> import yaml
> with open('/etc/salt/grains') as grains_file:
>     grains = yaml.full_load(grains_file)
> print(salt.utils.data.traverse_dict_and_list(grains, 'ceph-salt:execution:provisioned'))
> EOF
True
real	0m0.162s
user	0m0.149s
sys	0m0.013s
```



Fixes: https://github.com/ceph/ceph-salt/issues/223

Signed-off-by: Ricardo Marques <rimarques@suse.com>