### PR TITLE
chrony_sync_clock: wait longer for sync

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/files/chrony_sync_clock.sh
+++ b/ceph-salt-formula/salt/ceph-salt/files/chrony_sync_clock.sh
@@ -3,4 +3,4 @@ set -e
 chronyc 'burst 4/4'
 sleep 15
 chronyc makestep
-chronyc waitsync 30 0.04
+chronyc waitsync 60 0.04


### PR DESCRIPTION
I had a test fail because it exhausted all 30 tries without successfully
syncing with the remote time server.

Signed-off-by: Nathan Cutler <ncutler@suse.com>