### PR TITLE
Add 'cephadm' role

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,23 @@ set the initial deployment of your cluster:
 ceph-salt config
 ```
 
-First step of configuration is to add the salt-minions that should be used for
-deploying Ceph the command `add` under `/ceph_cluster/minions` option supports
-autocomplete and glob expressions:
+First step of configuration is to add the salt-minions that should be managed
+by`ceph-salt`.
+The `add` command under `/ceph_cluster/minions` option supports autocomplete
+and glob expressions:
 
 ```
 /ceph_cluster/minions add *
 ```
 
-Then we must specify which minions will have "ceph.conf" and "keyring" installed:
+Then we must specify which minions will be used to deploy Ceph.
+Those minions will be Ceph nodes controlled by cephadm:
+
+```
+/ceph_cluster/roles/cephadm add *
+```
+
+And which of them will have "ceph.conf" and "keyring" installed:
 
 ```
 /ceph_cluster/roles/admin add *

--- a/ceph-salt-formula/salt/ceph-salt/cephorch.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephorch.sls
@@ -1,8 +1,12 @@
 {% import 'macros.yml' as macros %}
 
+{% if 'cephadm' in grains['ceph-salt']['roles'] %}
+
 {{ macros.begin_stage('Add host to ceph orchestrator') }}
 add host to ceph orch:
   ceph_orch.add_host:
     - host: {{ grains['host'] }}
     - failhard: True
 {{ macros.end_stage('Add host to ceph orchestrator') }}
+
+{% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephtools.sls
@@ -1,5 +1,7 @@
 {% import 'macros.yml' as macros %}
 
+{% if 'cephadm' in grains['ceph-salt']['roles'] %}
+
 {{ macros.begin_stage('Prepare to bootstrap the Ceph cluster') }}
 
 {{ macros.begin_step('Install cephadm and other packages') }}
@@ -44,3 +46,5 @@ download ceph container image:
 {{ macros.end_step('Download ceph container image') }}
 
 {{ macros.end_stage('Prepare to bootstrap the Ceph cluster') }}
+
+{% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/find-admin-host.sls
+++ b/ceph-salt-formula/salt/ceph-salt/find-admin-host.sls
@@ -1,7 +1,11 @@
 {% import 'macros.yml' as macros %}
 
+{% if 'cephadm' in grains['ceph-salt']['roles'] %}
+
 {{ macros.begin_stage('Wait for an admin host') }}
 wait for admin host:
   ceph_orch.wait_for_admin_host:
     - failhard: True
 {{ macros.end_stage('Wait for an admin host') }}
+
+{% endif %}

--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -352,6 +352,11 @@ CEPH_SALT_OPTIONS = {
                         'required': True,
                         'default_text': 'no minion'
                     },
+                    'cephadm': {
+                        'type': 'minions',
+                        'handler': RoleHandler('cephadm'),
+                        'help': 'List of minions with Cephadm role'
+                    },
                 }
             },
         }
@@ -1243,6 +1248,8 @@ def run_import(config_file):
         node = CephNode(minion)
         if minion in minions_config.get('admin', []):
             node.add_role('admin')
+        if minion in minions_config.get('cephadm', []):
+            node.add_role('cephadm')
         node.save()
     PP.pl_green('Configuration imported.')
     return True

--- a/ceph_salt/core.py
+++ b/ceph_salt/core.py
@@ -123,6 +123,9 @@ class CephNodeManager:
         PillarManager.set('ceph-salt:minions:admin',
                           [n.minion_id for n in cls._ceph_salt_nodes.values()
                            if 'admin' in n.roles])
+        PillarManager.set('ceph-salt:minions:cephadm',
+                          [n.minion_id for n in cls._ceph_salt_nodes.values()
+                           if 'cephadm' in n.roles])
 
     @classmethod
     def ceph_salt_nodes(cls):

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -5,9 +5,9 @@ def validate_config(host_ls):
     """
     :return: Error message if config is invalid, otherwise "None"
     """
-    all_minions = PillarManager.get('ceph-salt:minions:all')
+    all_minions = PillarManager.get('ceph-salt:minions:all', [])
     bootstrap_minion = PillarManager.get('ceph-salt:bootstrap_minion')
-    admin_minions = PillarManager.get('ceph-salt:minions:admin')
+    admin_minions = PillarManager.get('ceph-salt:minions:admin', [])
     deployed = len(host_ls) > 0
     if not deployed:
         if not bootstrap_minion:
@@ -27,6 +27,17 @@ def validate_config(host_ls):
             return "No bootstrap Mon IP specified in config"
         if bootstrap_mon_ip in ['127.0.0.1', '::1']:
             return 'Mon IP cannot be the loopback interface IP'
+
+    # roles
+    cephadm_minions = PillarManager.get('ceph-salt:minions:cephadm', [])
+    for cephadm_minion in cephadm_minions:
+        if cephadm_minion not in all_minions:
+            return "Minion '{}' has 'cephadm' role but is not a cluster "\
+                   "minion".format(cephadm_minion)
+    for admin_minion in admin_minions:
+        if admin_minion not in cephadm_minions:
+            return "Minion '{}' has 'admin' role but not 'cephadm' "\
+                   "role".format(admin_minion)
 
     # system_update
     if not isinstance(PillarManager.get('ceph-salt:updates:enabled'), bool):
@@ -55,9 +66,6 @@ def validate_config(host_ls):
             return 'No external time servers specified in config'
         if not time_server_is_minion and external_time_servers:
             return not_minion_err.format('external time servers')
-    for admin_minion in admin_minions:
-        if admin_minion not in all_minions:
-            return "One or more Admin nodes are not cluster minions"
     ceph_container_image_path = PillarManager.get('ceph-salt:container:images:ceph')
     if not ceph_container_image_path:
         return "No Ceph container image path specified in config"

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -227,6 +227,8 @@ class ConfigShellTest(SaltMockTestCase):
     def test_export(self):
         self.shell.run_cmdline('/ceph_cluster/minions add node1.ceph.com')
         self.shell.run_cmdline('/ceph_cluster/minions add node2.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/roles/cephadm add node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/roles/cephadm add node2.ceph.com')
         self.shell.run_cmdline('/ceph_cluster/roles/admin add node1.ceph.com')
         self.shell.run_cmdline('/time_server/server_hostname set node1.ceph.com')
         self.shell.run_cmdline('/time_server/subnet set 10.20.188.0/24')
@@ -241,7 +243,8 @@ class ConfigShellTest(SaltMockTestCase):
             },
             'minions': {
                 'all': ['node1.ceph.com', 'node2.ceph.com'],
-                'admin': ['node1.ceph.com']
+                'admin': ['node1.ceph.com'],
+                'cephadm': ['node1.ceph.com', 'node2.ceph.com']
             },
             'time_server': {
                 'enabled': True,
@@ -256,6 +259,8 @@ class ConfigShellTest(SaltMockTestCase):
         self.shell.run_cmdline('/time_server/subnet reset')
         self.shell.run_cmdline('/time_server/server_hostname reset')
         self.shell.run_cmdline('/ceph_cluster/roles/admin remove node1.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/roles/cephadm remove node2.ceph.com')
+        self.shell.run_cmdline('/ceph_cluster/roles/cephadm remove node1.ceph.com')
         self.shell.run_cmdline('/ceph_cluster/minions remove node2.ceph.com')
         self.shell.run_cmdline('/ceph_cluster/minions remove node1.ceph.com')
 

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -84,10 +84,16 @@ class ValidateConfigTest(SaltMockTestCase):
             validate_config([]),
             not_minion_err.format('external time servers'))
 
-    def test_admin_not_cluster_minion(self):
+    def test_cephadm_not_cluster_minion(self):
+        PillarManager.set('ceph-salt:minions:cephadm', ['node4.ceph.com'])
+        self.assertEqual(validate_config([]),
+                         "Minion 'node4.ceph.com' has 'cephadm' role but is not a cluster minion")
+
+    def test_admin_without_cephadm_role(self):
         PillarManager.set('ceph-salt:bootstrap_minion', 'node3.ceph.com')
         PillarManager.set('ceph-salt:minions:admin', ['node3.ceph.com'])
-        self.assertEqual(validate_config([]), "One or more Admin nodes are not cluster minions")
+        self.assertEqual(validate_config([]),
+                         "Minion 'node3.ceph.com' has 'admin' role but not 'cephadm' role")
 
     def test_no_ceph_container_image_path(self):
         PillarManager.reset('ceph-salt:container:images:ceph')
@@ -107,7 +113,11 @@ class ValidateConfigTest(SaltMockTestCase):
         PillarManager.set('ceph-salt:time_server:server_host', 'node1.ceph.com')
         PillarManager.set('ceph-salt:time_server:external_time_servers', ['pool.ntp.org'])
         PillarManager.set('ceph-salt:time_server:subnet', '10.20.188.0/24')
-        PillarManager.set('ceph-salt:minions:all', ['node1.ceph.com', 'node2.ceph.com'])
+        PillarManager.set('ceph-salt:minions:all', ['node1.ceph.com',
+                                                    'node2.ceph.com',
+                                                    'node3.ceph.com'])
+        PillarManager.set('ceph-salt:minions:cephadm', ['node1.ceph.com',
+                                                        'node2.ceph.com'])
         PillarManager.set('ceph-salt:minions:admin', ['node1.ceph.com'])
         PillarManager.set('ceph-salt:updates:enabled', True)
         PillarManager.set('ceph-salt:updates:reboot', True)


### PR DESCRIPTION
This PR adds a new `cephadm` role.

A minion with `cephadm` role is a node that will be controlled by cephadm/ceph orchestrator.

Fixes: https://github.com/ceph/ceph-salt/issues/217

Signed-off-by: Ricardo Marques <rimarques@suse.com>