### PR TITLE
chrony_sync_clock.sh: run first chronyc in try-wait loop

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/files/chrony_sync_clock.sh
+++ b/ceph-salt-formula/salt/ceph-salt/files/chrony_sync_clock.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
-chronyc 'burst 4/4'
+# address https://github.com/ceph/ceph-salt/issues/238
+# by waiting up to 5 minutes for chrony to see its sources
+for trywait in "$(seq 0 9)" ; do
+    chronyc 'burst 4/4' && break || true
+    sleep 30
+done
 sleep 15
 chronyc makestep
 chronyc waitsync 60 0.04


### PR DESCRIPTION
Fixes: https://github.com/ceph/ceph-salt/issues/238
Signed-off-by: Nathan Cutler <ncutler@suse.com>