### PR TITLE
Persist journal logs

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/software.sls
+++ b/ceph-salt-formula/salt/ceph-salt/software.sls
@@ -10,6 +10,14 @@ install required packages:
       - podman
     - failhard: True
 
+/var/log/journal:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: '0755'
+    - makedirs: True
+    - failhard: True
+
 {% if pillar['ceph-salt']['updates']['enabled'] %}
 
 {{ macros.begin_step('Update all packages') }}


### PR DESCRIPTION
Create `/var/log/journal` directory, so journal logs will be persisted.

Fixes: https://github.com/ceph/ceph-salt/issues/240

Signed-off-by: Ricardo Marques <rimarques@suse.com>