### PR TITLE
Sanity check external time servers before applying config

### DIFF
--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -48,6 +48,9 @@ Requires:       python3-PyYAML >= 5.1.2
 Requires:       python3-setuptools
 Requires:       python3-salt >= 3000
 Requires:       python3-curses
+Requires:       netcat-openbsd
+%else
+Requires:       nc 
 %endif
 
 Requires:       ceph-salt-formula

--- a/ceph_salt/exceptions.py
+++ b/ceph_salt/exceptions.py
@@ -32,3 +32,14 @@ class MinionDoesNotExistInConfiguration(CephSaltException):
 
 class ParamsException(CephSaltException):
     pass
+
+
+class CmdException(CephSaltException):
+    def __init__(self, command, retcode, stderr):
+        super(CmdException, self).__init__(
+            "Command '{}' failed: ret={} stderr:\n{}"
+            .format(command, retcode, stderr)
+        )
+        self.command = command
+        self.retcode = retcode
+        self.stderr = stderr


### PR DESCRIPTION
References: https://github.com/ceph/ceph-salt/issues/241
Signed-off-by: Nathan Cutler <ncutler@suse.com>