### PR TITLE
apply: probe external time servers

### DIFF
--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -48,6 +48,7 @@ Requires:       python3-PyYAML >= 5.1.2
 Requires:       python3-setuptools
 Requires:       python3-salt >= 3000
 Requires:       python3-curses
+Requires:       python3-ntplib >= 3.3
 %endif
 
 Requires:       ceph-salt-formula

--- a/ceph_salt/apply.py
+++ b/ceph_salt/apply.py
@@ -15,7 +15,7 @@ import yaml
 from .core import CephNode, CephNodeManager
 from .exceptions import MinionDoesNotExistInConfiguration, ValidationException
 from .salt_event import EventListener, SaltEventProcessor
-from .salt_utils import SaltClient, GrainsManager, CephOrch
+from .salt_utils import SaltClient, GrainsManager, CephOrch, PillarManager
 from .terminal_utils import PrettyPrinter as PP
 from .validate.config import validate_config
 from .validate.salt_master import check_salt_master_status
@@ -1269,6 +1269,28 @@ class CephSaltExecutor:
         return 0
 
     @staticmethod
+    def check_external_time_servers(ts_minion, external_ts_list):
+        PP.println("Installing python3-ntplib on time server node...")
+        salt_result = SaltClient.local().cmd(
+            ts_minion, 'pkg.install', ["name='python3-ntplib'", "refresh=True"]
+        )
+        for external_ts in external_ts_list:
+            PP.println("Probing external time server {}...".format(external_ts))
+            salt_result = SaltClient.local().cmd(
+                ts_minion, 'ceph_salt.probe_ntp', [external_ts]
+            )
+            if not salt_result[ts_minion]:
+                logger.error(
+                    "external time server %s did not respond to probe", external_ts
+                )
+                PP.pl_red(
+                    "External time server '{}' did not respond to probe"
+                    .format(external_ts)
+                )
+                return 1
+        return 0
+
+    @staticmethod
     def check_apply_prerequisites(minion_id):
         # check salt master is configured
         try:
@@ -1296,6 +1318,19 @@ class CephSaltExecutor:
         retcode = CephSaltExecutor.check_cluster(minion_id, host_ls)
         if retcode > 0:
             return retcode
+
+        # check external time servers, if any
+        time_server_enabled = PillarManager.get('ceph-salt:time_server:enabled')
+        if time_server_enabled:
+            time_server_host = PillarManager.get('ceph-salt:time_server:server_host')
+            external_time_servers = PillarManager.get('ceph-salt:time_server:external_time_servers')
+            if external_time_servers:
+                retcode = CephSaltExecutor.check_external_time_servers(
+                    time_server_host,
+                    external_time_servers
+                )
+                if retcode > 0:
+                    return retcode
 
         PP.println("Ready to apply config!")
         return 0


### PR DESCRIPTION
Since the external time servers come from user input, they might contain
typos or otherwise be unfit for use. Probe them, first, as part of config
validation, before proceeding to install chrony, etc.

References: https://github.com/ceph/ceph-salt/pull/245
Signed-off-by: Nathan Cutler <ncutler@suse.com>