### PR TITLE
apply: probe external time servers (V2)

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -1,5 +1,7 @@
 # -*- encoding: utf-8 -*-
 import json
+import ntplib
+import socket
 
 def get_remote_grain(host, grain):
     """
@@ -24,3 +26,16 @@ def set_remote_grain(host, grain, value):
     return __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
                                    "-i /tmp/ceph-salt-ssh-id_rsa root@{} "
                                    "'salt-call grains.set {} {}'".format(host, grain, value))
+
+def probe_ntp(ahost):
+    conn = ntplib.NTPClient()
+    success = False
+    try:
+        conn.request(ahost, version=3)
+        return 0
+    except socket.gaierror:
+        return 2
+    except ntplib.NTPException:
+        return 1
+    except:
+        return 3

--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -48,6 +48,7 @@ Requires:       python3-PyYAML >= 5.1.2
 Requires:       python3-setuptools
 Requires:       python3-salt >= 3000
 Requires:       python3-curses
+Requires:       python3-ntplib >= 3.3
 %endif
 
 Requires:       ceph-salt-formula


### PR DESCRIPTION
Since the external time servers come from user input, they might contain
typos or otherwise be unfit for use. If they are present, probe them
first, before trying to apply the configuration.

References: https://github.com/ceph/ceph-salt/pull/245
Signed-off-by: Nathan Cutler <ncutler@suse.com>