### PR TITLE
Fix python3-ntplib required version

### DIFF
--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -48,7 +48,7 @@ Requires:       python3-PyYAML >= 5.1.2
 Requires:       python3-setuptools
 Requires:       python3-salt >= 3000
 Requires:       python3-curses
-Requires:       python3-ntplib >= 3.3
+Requires:       python3-ntplib >= 0.3.3
 %endif
 
 Requires:       ceph-salt-formula


### PR DESCRIPTION
Should be `0.3.3` instead of `3.3` - https://pkgs.org/search/?q=python3-ntplib

Signed-off-by: Ricardo Marques <rimarques@suse.com>