### PR TITLE
Rely on "bootstrap" to configure MGR module (and more...)

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
@@ -47,7 +47,8 @@ run cephadm bootstrap:
                 --skip-monitoring-stack \
                 --skip-prepare-host \
                 --skip-pull \
-                --skip-ssh \
+                --ssh-private-key /tmp/ceph-salt-ssh-id_rsa \
+                --ssh-public-key /tmp/ceph-salt-ssh-id_rsa.pub \
 {%- for arg, value in pillar['ceph-salt'].get('bootstrap_arguments', {}).items() %}
                 --{{ arg }} {{ value if value is not none else '' }} \
 {%- endfor %}
@@ -60,21 +61,6 @@ run cephadm bootstrap:
     - failhard: True
 
 {{ macros.end_step('Run "cephadm bootstrap"') }}
-
-{{ macros.begin_step('Configure cephadm MGR module') }}
-
-configure ssh orchestrator:
-  cmd.run:
-    - name: |
-        ceph config-key set mgr/cephadm/ssh_identity_key -i /tmp/ceph-salt-ssh-id_rsa
-        ceph config-key set mgr/cephadm/ssh_identity_pub -i /tmp/ceph-salt-ssh-id_rsa.pub
-        ceph mgr module enable cephadm && \
-        ceph orch set backend cephadm
-    - onchanges:
-      - cmd: run cephadm bootstrap
-    - failhard: True
-
-{{ macros.end_step('Configure cephadm MGR module') }}
 
 {{ macros.end_stage('Bootstrap the Ceph cluster') }}
 

--- a/ceph-salt-formula/salt/ceph-salt/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephtools.sls
@@ -15,7 +15,7 @@ install cephadm:
 {% endif %}
     - failhard: True
 
-{% if grains['id'] == pillar['ceph-salt']['bootstrap_minion'] %}
+{% if grains['id'] == pillar['ceph-salt'].get('bootstrap_minion') %}
 /var/log/ceph:
   file.directory:
     - user: ceph

--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -436,11 +436,13 @@ CEPH_SALT_OPTIONS = {
         }
     },
     'cephadm_bootstrap': {
+        'type': 'group',
         'help': '''
                 Cluster Bootstrap Options Configuration
                 =========================================
                 Options to control the Ceph cluster bootstrap
                 ''',
+        'handler': FlagGroupHandler('ceph-salt:bootstrap_enabled', True),
         'options': {
             'advanced': {
                 'type': 'dict',

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -9,12 +9,14 @@ def validate_config(host_ls):
     all_minions = PillarManager.get('ceph-salt:minions:all', [])
     bootstrap_minion = PillarManager.get('ceph-salt:bootstrap_minion')
     admin_minions = PillarManager.get('ceph-salt:minions:admin', [])
+    bootstrap_enabled = PillarManager.get('ceph-salt:bootstrap_enabled')
     deployed = len(host_ls) > 0
     if not deployed:
         if not bootstrap_minion:
             return "No bootstrap minion specified in config"
         if bootstrap_minion not in admin_minions:
             return "Bootstrap minion must be 'Admin'"
+    if bootstrap_enabled:
         dashboard_username = PillarManager.get('ceph-salt:dashboard:username')
         if not dashboard_username:
             return "No dashboard username specified in config"

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -151,6 +151,11 @@ class ConfigShellTest(SaltMockTestCase):
                               'mgr-id',
                               'y')
 
+    def test_cephadm_bootstrap(self):
+        self.assertFlagOption('/cephadm_bootstrap',
+                              'ceph-salt:bootstrap_enabled',
+                              reset_supported=False)
+
     def test_cephadm_bootstrap_ceph_conf(self):
         self.assertConfigOption('/cephadm_bootstrap/ceph_conf',
                                 'ceph-salt:bootstrap_ceph_conf')
@@ -246,6 +251,7 @@ class ConfigShellTest(SaltMockTestCase):
 
         self.assertTrue(run_export(False))
         self.assertJsonInSysOut({
+            'bootstrap_enabled': True,
             'dashboard': {
                 'username': 'admin',
                 'password': PillarManager.get('ceph-salt:dashboard:password'),

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -45,6 +45,11 @@ PBVw2pLCZsH5ol3VJ1/DETsGRMzFubFeTUNOC3MzhhG+V"""
         PillarManager.reset('ceph-salt:bootstrap_mon_ip')
         self.assertEqual(validate_config([]), "No bootstrap Mon IP specified in config")
 
+    def test_no_bootstrap_mon_ip_bootstrap_disabled(self):
+        PillarManager.set('ceph-salt:bootstrap_enabled', False)
+        PillarManager.reset('ceph-salt:bootstrap_mon_ip')
+        self.assertIsNone(validate_config([]))
+
     def test_loopback_bootstrap_mon_ip(self):
         PillarManager.set('ceph-salt:bootstrap_mon_ip', '127.0.0.1')
         self.assertEqual(validate_config([]), "Mon IP cannot be the loopback interface IP")
@@ -184,6 +189,7 @@ BJGDcEjQZ0KwFnaPfCMTXwnWaMHfGA9k7VrDZwxpTfGQ0b2cl+tCk7by/SCmDW6k
 RpDBiJHfMFDSRysZrjmuULRJvcrItRg2r3TIVuB8Wxze7Ugyb9G4hH7ZIW1y9QlG
 SCzirUzUKN2oge2WieNI7MQ=
 -----END PRIVATE KEY-----""")
+        PillarManager.set('ceph-salt:bootstrap_enabled', True)
         PillarManager.set('ceph-salt:bootstrap_minion', 'node1.ceph.com')
         PillarManager.set('ceph-salt:bootstrap_mon_ip', '10.20.188.201')
         PillarManager.set('ceph-salt:time_server:enabled', True)


### PR DESCRIPTION
~~**After https://github.com/ceph/ceph/pull/35195**~~
~~**After https://github.com/ceph/ceph/pull/35347**~~

---

This PR contains two commits, each commit fixes a different issue.

**1. Need to invoke `ceph orch apply crash`** (https://github.com/ceph/ceph-salt/issues/236)

We will now rely on `cephadm bootstrap` to configure `cephadm` MGR module, which will guarantee that all initializations are properly done (including the execution of `ceph orch apply crash`)

**2. Make bootstrap_mon optional** (https://github.com/ceph/ceph-salt/issues/265)

It's now possible to explicitly say that we don't want `ceph-salt` to run `cephadm bootstrap` by setting `ceph-salt config /cephadm_bootstrap disable`, so the new behavior is:
1) `bootstrap_minion` is required for initial `ceph-salt apply` execution but can be removed latter if needed/wanted.
2) If `bootstrap is enabled`, then `/cephadm_bootstrap/*` options are required (including `mon_ip`). In this scenario `cephadm bootstrap` will be executed on the `bootstrap_minion`.
3) If `bootstrap is disabled`, then `/cephadm_bootstrap/*` options will be ignored and `ceph-salt` will assume that `bootstrap_minion` has access to a running cluster (e.g. an upgrade from Nautilus to Octopus). In this scenario `ceph-salt` will simply configure/enable cephadm MGR module.



Signed-off-by: Ricardo Marques <rimarques@suse.com>