### PR TITLE
Install ceph-salt ssh keys on admin minions

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -36,8 +36,9 @@ def get_remote_grain(host, grain):
     """
     ssh_user = __pillar__['ceph-salt']['ssh']['user']
     sudo = 'sudo ' if ssh_user != 'root' else ''
+    home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'    
     ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                  "-i /tmp/ceph-salt-ssh-id_rsa {}@{} "
+                                  "-i {}/.ssh/ceph-salt {}@{} "
                                   "\"{}python3 - <<EOF\n"
                                   "import json\n"
                                   "import salt.utils.data\n"
@@ -46,7 +47,7 @@ def get_remote_grain(host, grain):
                                   "    grains = yaml.full_load(grains_file)\n"
                                   "val = salt.utils.data.traverse_dict_and_list(grains, '{}')\n"
                                   "print(json.dumps({{'local': val}}))\n"
-                                  "EOF\"".format(ssh_user, host, sudo, grain))
+                                  "EOF\"".format(home, ssh_user, host, sudo, grain))
     if ret['retcode'] != 0:
         return None
     return json.loads(ret['stdout'])['local']

--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -38,7 +38,7 @@ def get_remote_grain(host, grain):
     sudo = 'sudo ' if ssh_user != 'root' else ''
     home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'    
     ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                  "-i {}/.ssh/ceph-salt {}@{} "
+                                  "-i {}/.ssh/id_rsa {}@{} "
                                   "\"{}python3 - <<EOF\n"
                                   "import json\n"
                                   "import salt.utils.data\n"

--- a/ceph-salt-formula/salt/_states/ceph_orch.py
+++ b/ceph-salt-formula/salt/_states/ceph_orch.py
@@ -35,12 +35,14 @@ def set_admin_host(name, if_grain=None, timeout=1800):
                 if provisioned:
                     ssh_user = __pillar__['ceph-salt']['ssh']['user']
                     sudo = 'sudo ' if ssh_user != 'root' else ''
+                    home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'                
                     status_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                                         "-i /tmp/ceph-salt-ssh-id_rsa {}@{} "
+                                                         "-i {}/.ssh/ceph-salt {}@{} "
                                                          "'if [[ -f /etc/ceph/ceph.conf "
                                                          "&& -f /etc/ceph/ceph.client.admin.keyring ]]; "
                                                          "then timeout 60 {}ceph -s; "
                                                          "else (exit 1); fi'".format(
+                                                             home,
                                                              ssh_user,
                                                              admin_host,
                                                              sudo))
@@ -71,12 +73,14 @@ def wait_until_ceph_orch_available(name, timeout=1800):
         admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
         ssh_user = __pillar__['ceph-salt']['ssh']['user']
         sudo = 'sudo ' if ssh_user != 'root' else ''
+        home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'    
         status_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                             "-i /tmp/ceph-salt-ssh-id_rsa {}@{} "
+                                             "-i {}/.ssh/ceph-salt {}@{} "
                                              "'if [[ -f /etc/ceph/ceph.conf "
                                              "&& -f /etc/ceph/ceph.client.admin.keyring ]]; "
                                              "then timeout 60 {}ceph orch status --format=json; "
                                              "else (exit 1); fi'".format(
+                                                 home,
                                                  ssh_user,
                                                  admin_host,
                                                  sudo))
@@ -96,10 +100,11 @@ def add_host(name, host):
     admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
     ssh_user = __pillar__['ceph-salt']['ssh']['user']
     sudo = 'sudo ' if ssh_user != 'root' else ''
+    home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'
     cmd_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                      "-i /tmp/ceph-salt-ssh-id_rsa {}@{} "
-                                      "'{}ceph orch host add {}'".format(ssh_user, admin_host,
-                                                                       sudo, host))
+                                      "-i {}/.ssh/ceph-salt {}@{} "
+                                      "'{}ceph orch host add {}'".format(home, ssh_user,
+                                                                         admin_host, sudo, host))
     if cmd_ret['retcode'] == 0:
         ret['result'] = True
     return ret
@@ -136,11 +141,12 @@ def copy_ceph_conf_and_keyring(name):
     admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
     ssh_user = __pillar__['ceph-salt']['ssh']['user']
     sudo = 'sudo ' if ssh_user != 'root' else ''
-    cmd_ret = __salt__['cmd.run_all']("{0}rsync --rsync-path='{0}rsync' "
+    home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'
+    cmd_ret = __salt__['cmd.run_all']("{1}rsync --rsync-path='{1}rsync' "
                                       "-e 'ssh -o StrictHostKeyChecking=no "
-                                      "-i /tmp/ceph-salt-ssh-id_rsa' "
-                                      "{1}@{2}:/etc/ceph/{{ceph.conf,ceph.client.admin.keyring}} "
-                                      "/etc/ceph/".format(sudo, ssh_user, admin_host))
+                                      "-i {0}/.ssh/ceph-salt' "
+                                      "{2}@{3}:/etc/ceph/{{ceph.conf,ceph.client.admin.keyring}} "
+                                      "/etc/ceph/".format(home, sudo, ssh_user, admin_host))
     if cmd_ret['retcode'] == 0:
         ret['result'] = True
     return ret
@@ -168,10 +174,14 @@ def wait_for_ceph_orch_host_ok_to_stop(name, if_grain, timeout=36000):
             admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
             ssh_user = __pillar__['ceph-salt']['ssh']['user']
             sudo = 'sudo ' if ssh_user != 'root' else ''
+            home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'    
             cmd_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                              "-i /tmp/ceph-salt-ssh-id_rsa {}@{} "
-                                              "'{}ceph orch host ok-to-stop {}'".format(ssh_user, admin_host,
-                                                                                        sudo, host))
+                                              "-i {}/.ssh/ceph-salt {}@{} "
+                                              "'{}ceph orch host ok-to-stop {}'".format(home,
+                                                                                        ssh_user,
+                                                                                        admin_host,
+                                                                                        sudo,
+                                                                                        host))
             ok_to_stop = cmd_ret['retcode'] == 0
             if not ok_to_stop:
                 logger.info("Waiting for 'ceph_orch.host_ok_to_stop'")

--- a/ceph-salt-formula/salt/_states/ceph_orch.py
+++ b/ceph-salt-formula/salt/_states/ceph_orch.py
@@ -37,7 +37,7 @@ def set_admin_host(name, if_grain=None, timeout=1800):
                     sudo = 'sudo ' if ssh_user != 'root' else ''
                     home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'                
                     status_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                                         "-i {}/.ssh/ceph-salt {}@{} "
+                                                         "-i {}/.ssh/id_rsa {}@{} "
                                                          "'if [[ -f /etc/ceph/ceph.conf "
                                                          "&& -f /etc/ceph/ceph.client.admin.keyring ]]; "
                                                          "then timeout 60 {}ceph -s; "
@@ -75,7 +75,7 @@ def wait_until_ceph_orch_available(name, timeout=1800):
         sudo = 'sudo ' if ssh_user != 'root' else ''
         home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'    
         status_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                             "-i {}/.ssh/ceph-salt {}@{} "
+                                             "-i {}/.ssh/id_rsa {}@{} "
                                              "'if [[ -f /etc/ceph/ceph.conf "
                                              "&& -f /etc/ceph/ceph.client.admin.keyring ]]; "
                                              "then timeout 60 {}ceph orch status --format=json; "
@@ -102,7 +102,7 @@ def add_host(name, host):
     sudo = 'sudo ' if ssh_user != 'root' else ''
     home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'
     cmd_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                      "-i {}/.ssh/ceph-salt {}@{} "
+                                      "-i {}/.ssh/id_rsa {}@{} "
                                       "'{}ceph orch host add {}'".format(home, ssh_user,
                                                                          admin_host, sudo, host))
     if cmd_ret['retcode'] == 0:
@@ -144,7 +144,7 @@ def copy_ceph_conf_and_keyring(name):
     home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'
     cmd_ret = __salt__['cmd.run_all']("{1}rsync --rsync-path='{1}rsync' "
                                       "-e 'ssh -o StrictHostKeyChecking=no "
-                                      "-i {0}/.ssh/ceph-salt' "
+                                      "-i {0}/.ssh/id_rsa' "
                                       "{2}@{3}:/etc/ceph/{{ceph.conf,ceph.client.admin.keyring}} "
                                       "/etc/ceph/".format(home, sudo, ssh_user, admin_host))
     if cmd_ret['retcode'] == 0:
@@ -176,7 +176,7 @@ def wait_for_ceph_orch_host_ok_to_stop(name, if_grain, timeout=36000):
             sudo = 'sudo ' if ssh_user != 'root' else ''
             home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'    
             cmd_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                              "-i {}/.ssh/ceph-salt {}@{} "
+                                              "-i {}/.ssh/id_rsa {}@{} "
                                               "'{}ceph orch host ok-to-stop {}'".format(home,
                                                                                         ssh_user,
                                                                                         admin_host,

--- a/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
@@ -5,14 +5,14 @@
 {{ macros.begin_stage('Ensure cephadm MGR module is configured') }}
 
 {% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
-{% set home = '/home/{{ ssh_user }}' if ssh_user != 'root' else '/root' %}
+{% set home = '/home/' ~ssh_user if ssh_user != 'root' else '/root' %}
 {% set auth = pillar['ceph-salt'].get('container', {}).get('auth', {}) %}
 
 configure cephadm mgr module:
   cmd.run:
     - name: |
-        ceph cephadm set-priv-key -i {{ home }}/.ssh/ceph-salt
-        ceph cephadm set-pub-key -i {{ home }}/.ssh/ceph-salt.pub
+        ceph cephadm set-priv-key -i {{ home }}/.ssh/id_rsa
+        ceph cephadm set-pub-key -i {{ home }}/.ssh/id_rsa.pub
         ceph cephadm set-user {{ ssh_user }}
 {%- if auth %}
         ceph cephadm registry-login -i /tmp/ceph-salt-registry-json

--- a/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
@@ -5,13 +5,14 @@
 {{ macros.begin_stage('Ensure cephadm MGR module is configured') }}
 
 {% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
+{% set home = '/home/{{ ssh_user }}' if ssh_user != 'root' else '/root' %}
 {% set auth = pillar['ceph-salt'].get('container', {}).get('auth', {}) %}
 
 configure cephadm mgr module:
   cmd.run:
     - name: |
-        ceph cephadm set-priv-key -i /tmp/ceph-salt-ssh-id_rsa
-        ceph cephadm set-pub-key -i /tmp/ceph-salt-ssh-id_rsa.pub
+        ceph cephadm set-priv-key -i {{ home }}/.ssh/ceph-salt
+        ceph cephadm set-pub-key -i {{ home }}/.ssh/ceph-salt.pub
         ceph cephadm set-user {{ ssh_user }}
 {%- if auth %}
         ceph cephadm registry-login -i /tmp/ceph-salt-registry-json

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -42,6 +42,7 @@ create bootstrap ceph conf:
 {% set dashboard_username = pillar['ceph-salt']['dashboard']['username'] %}
 {% set dashboard_password = pillar['ceph-salt']['dashboard']['password'] %}
 {% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
+{% set home = '/home/' ~ssh_user if ssh_user != 'root' else '/root' %}
 {% set auth = pillar['ceph-salt'].get('container', {}).get('auth', {}) %}
 
 {# --mon-ip is still required, even though we're also putting the Mon IP      #}
@@ -67,8 +68,8 @@ run cephadm bootstrap:
                 --skip-monitoring-stack \
                 --skip-prepare-host \
                 --skip-pull \
-                --ssh-private-key /tmp/ceph-salt-ssh-id_rsa \
-                --ssh-public-key /tmp/ceph-salt-ssh-id_rsa.pub \
+                --ssh-private-key {{ home }}/.ssh/ceph-salt \
+                --ssh-public-key {{ home }}/.ssh/ceph-salt.pub \
                 --ssh-user {{ ssh_user }} \
 {%- for arg, value in pillar['ceph-salt'].get('bootstrap_arguments', {}).items() %}
                 --{{ arg }} {{ value if value is not none else '' }} \

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -68,8 +68,8 @@ run cephadm bootstrap:
                 --skip-monitoring-stack \
                 --skip-prepare-host \
                 --skip-pull \
-                --ssh-private-key {{ home }}/.ssh/ceph-salt \
-                --ssh-public-key {{ home }}/.ssh/ceph-salt.pub \
+                --ssh-private-key {{ home }}/.ssh/id_rsa \
+                --ssh-public-key {{ home }}/.ssh/id_rsa.pub \
                 --ssh-user {{ ssh_user }} \
 {%- for arg, value in pillar['ceph-salt'].get('bootstrap_arguments', {}).items() %}
                 --{{ arg }} {{ value if value is not none else '' }} \

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephconfigure.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephconfigure.sls
@@ -26,13 +26,13 @@ copy ceph.conf and keyring from an admin node:
 {{ macros.begin_stage('Ensure cephadm MGR module is enabled') }}
 
 {% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
-{% set home = '/home/{{ ssh_user }}' if ssh_user != 'root' else '/root' %}
+{% set home = '/home/' ~ssh_user if ssh_user != 'root' else '/root' %}
 
 enable cephadm mgr module:
   cmd.run:
     - name: |
-        ceph config-key set mgr/cephadm/ssh_identity_key -i {{ home }}/.ssh/ceph-salt
-        ceph config-key set mgr/cephadm/ssh_identity_pub -i {{ home }}/.ssh/ceph-salt.pub
+        ceph config-key set mgr/cephadm/ssh_identity_key -i {{ home }}/.ssh/id_rsa
+        ceph config-key set mgr/cephadm/ssh_identity_pub -i {{ home }}/.ssh/id_rsa.pub
         ceph config-key set mgr/cephadm/ssh_user {{ ssh_user }}
         ceph mgr module enable cephadm && \
         ceph orch set backend cephadm

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephconfigure.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephconfigure.sls
@@ -26,12 +26,13 @@ copy ceph.conf and keyring from an admin node:
 {{ macros.begin_stage('Ensure cephadm MGR module is enabled') }}
 
 {% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
+{% set home = '/home/{{ ssh_user }}' if ssh_user != 'root' else '/root' %}
 
 enable cephadm mgr module:
   cmd.run:
     - name: |
-        ceph config-key set mgr/cephadm/ssh_identity_key -i /tmp/ceph-salt-ssh-id_rsa
-        ceph config-key set mgr/cephadm/ssh_identity_pub -i /tmp/ceph-salt-ssh-id_rsa.pub
+        ceph config-key set mgr/cephadm/ssh_identity_key -i {{ home }}/.ssh/ceph-salt
+        ceph config-key set mgr/cephadm/ssh_identity_pub -i {{ home }}/.ssh/ceph-salt.pub
         ceph config-key set mgr/cephadm/ssh_user {{ ssh_user }}
         ceph mgr module enable cephadm && \
         ceph orch set backend cephadm

--- a/ceph-salt-formula/salt/ceph-salt/apply/cleanup.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cleanup.sls
@@ -1,12 +1,19 @@
+{% if 'admin' not in grains['ceph-salt']['roles'] %}
+
+{% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
+{% set home = '/home/' ~ssh_user if ssh_user != 'root' else '/root' %}
+
 remove ceph-salt-ssh-id_rsa:
   file.absent:
-    - name: /tmp/ceph-salt-ssh-id_rsa
+    - name: {{ home }}/.ssh/ceph-salt
     - failhard: True
 
 remove ceph-salt-ssh-id_rsa.pub:
   file.absent:
-    - name: /tmp/ceph-salt-ssh-id_rsa.pub
+    - name: {{ home }}/.ssh/ceph-salt.pub
     - failhard: True
+
+{% endif %}
 
 remove ceph-salt-registry-json:
   file.absent:

--- a/ceph-salt-formula/salt/ceph-salt/apply/cleanup.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cleanup.sls
@@ -5,12 +5,12 @@
 
 remove ceph-salt-ssh-id_rsa:
   file.absent:
-    - name: {{ home }}/.ssh/ceph-salt
+    - name: {{ home }}/.ssh/id_rsa
     - failhard: True
 
 remove ceph-salt-ssh-id_rsa.pub:
   file.absent:
-    - name: {{ home }}/.ssh/ceph-salt.pub
+    - name: {{ home }}/.ssh/id_rsa.pub
     - failhard: True
 
 {% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
+++ b/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
@@ -38,7 +38,7 @@ create ssh dir:
 # private key
 create ceph-salt-ssh-id_rsa:
   file.managed:
-    - name: {{ home }}/.ssh/ceph-salt
+    - name: {{ home }}/.ssh/id_rsa
     - user: {{ ssh_user }}
     - group: {{ ssh_user_group }}
     - mode: '0600'
@@ -48,7 +48,7 @@ create ceph-salt-ssh-id_rsa:
 # public key
 create ceph-salt-ssh-id_rsa.pub:
   file.managed:
-    - name: {{ home }}/.ssh/ceph-salt.pub
+    - name: {{ home }}/.ssh/id_rsa.pub
     - user: {{ ssh_user }}
     - group: {{ ssh_user_group }}
     - mode: '0644'

--- a/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
+++ b/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
@@ -33,10 +33,12 @@ create ssh dir:
     - makedirs: True
     - failhard: True
 
+{% set home = '/home/' ~ssh_user if ssh_user != 'root' else '/root' %}
+
 # private key
 create ceph-salt-ssh-id_rsa:
   file.managed:
-    - name: /tmp/ceph-salt-ssh-id_rsa
+    - name: {{ home }}/.ssh/ceph-salt
     - user: {{ ssh_user }}
     - group: {{ ssh_user_group }}
     - mode: '0600'
@@ -46,7 +48,7 @@ create ceph-salt-ssh-id_rsa:
 # public key
 create ceph-salt-ssh-id_rsa.pub:
   file.managed:
-    - name: /tmp/ceph-salt-ssh-id_rsa.pub
+    - name: {{ home }}/.ssh/ceph-salt.pub
     - user: {{ ssh_user }}
     - group: {{ ssh_user_group }}
     - mode: '0644'

--- a/ceph-salt-formula/salt/ceph-salt/reboot/reboot-end.sls
+++ b/ceph-salt-formula/salt/ceph-salt/reboot/reboot-end.sls
@@ -3,12 +3,19 @@ set rebooted:
     - name: ceph-salt:execution:rebooted
     - value: True
 
+{% if 'admin' not in grains['ceph-salt']['roles'] %}
+
+{% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
+{% set home = '/home/' ~ssh_user if ssh_user != 'root' else '/root' %}
+
 remove ceph-salt-ssh-id_rsa:
   file.absent:
-    - name: /tmp/ceph-salt-ssh-id_rsa
+    - name: {{ home }}/.ssh/id_rsa
     - failhard: True
 
 remove ceph-salt-ssh-id_rsa.pub:
   file.absent:
-    - name: /tmp/ceph-salt-ssh-id_rsa.pub
+    - name: {{ home }}/.ssh/id_rsa.pub
     - failhard: True
+
+{% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/update/update-end.sls
+++ b/ceph-salt-formula/salt/ceph-salt/update/update-end.sls
@@ -3,12 +3,19 @@ set updated:
     - name: ceph-salt:execution:updated
     - value: True
 
+{% if 'admin' not in grains['ceph-salt']['roles'] %}
+
+{% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
+{% set home = '/home/{{ ssh_user }}' if ssh_user != 'root' else '/root' %}
+
 remove ceph-salt-ssh-id_rsa:
   file.absent:
-    - name: /tmp/ceph-salt-ssh-id_rsa
+    - name: {{ home }}/.ssh/ceph-salt
     - failhard: True
 
 remove ceph-salt-ssh-id_rsa.pub:
   file.absent:
-    - name: /tmp/ceph-salt-ssh-id_rsa.pub
+    - name: {{ home }}/.ssh/ceph-salt.pub
     - failhard: True
+
+{% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/update/update-end.sls
+++ b/ceph-salt-formula/salt/ceph-salt/update/update-end.sls
@@ -6,16 +6,16 @@ set updated:
 {% if 'admin' not in grains['ceph-salt']['roles'] %}
 
 {% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
-{% set home = '/home/{{ ssh_user }}' if ssh_user != 'root' else '/root' %}
+{% set home = '/home/' ~ssh_user if ssh_user != 'root' else '/root' %}
 
 remove ceph-salt-ssh-id_rsa:
   file.absent:
-    - name: {{ home }}/.ssh/ceph-salt
+    - name: {{ home }}/.ssh/id_rsa
     - failhard: True
 
 remove ceph-salt-ssh-id_rsa.pub:
   file.absent:
-    - name: {{ home }}/.ssh/ceph-salt.pub
+    - name: {{ home }}/.ssh/id_rsa.pub
     - failhard: True
 
 {% endif %}


### PR DESCRIPTION
With this PR, SSH keys will be installed in `/root/.ssh` (instead of `/tmp`), and if the node has the `admin` role, then those keys will not be removed after execution.

The user will then be able to SSH from one `admin` node to any other node by running:

```
master:~ # ssh node2 -i ~/.ssh/ceph-salt
Last login: Mon Jun  1 15:35:54 2020 from 10.20.162.200
Have a lot of fun...
node2:~ # 
```

~~Note that we are not using the default name (`id_rsa`) to guarantee that we will not override existing keys.~~

Fixes: https://github.com/ceph/ceph-salt/issues/191

Signed-off-by: Ricardo Marques <rimarques@suse.com>