### PR TITLE
Add "Conflicts: deepsea" to spec file

### DIFF
--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -55,6 +55,7 @@ Requires:       ceph-salt-formula
 Requires:       salt-master >= 3000
 Requires:       procps
 
+Conflicts:      deepsea
 
 %description
 ceph-salt is a CLI tool for deploying Ceph clusters starting from version


### PR DESCRIPTION
This ensures that when installing ceph-salt, deepsea will be removed (`zypper in` will say something like "Problem: ceph-salt conflicts with deepsea - solution 1: deinstallation of deepsea, solution 2: do not install ceph-salt").

Signed-off-by: Tim Serong <tserong@suse.com>