### PR TITLE
Allow users to disable custom registries configuration

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/container.sls
+++ b/ceph-salt-formula/salt/ceph-salt/container.sls
@@ -1,5 +1,7 @@
 {% import 'macros.yml' as macros %}
 
+{% if pillar['ceph-salt']['container']['registries_enabled'] %}
+
 {{ macros.begin_stage('Set up container environment') }}
 
 {{ macros.begin_step('Configure container image registries') }}
@@ -18,3 +20,5 @@
 {{ macros.end_step('Configure container image registries') }}
 
 {{ macros.end_stage('Set up container environment') }}
+
+{% endif %}

--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -388,31 +388,38 @@ CEPH_SALT_OPTIONS = {
                     },
                 }
             },
-            'registries': {
-                'type': 'list_dict',
-                'help': '''
-                        List of custom registries in v2 format.
-                        =======================================
+            'registries_conf': {
+                'type': 'group',
+                'help': "Custom registries configuration",
+                'handler': FlagGroupHandler('ceph-salt:container:registries_enabled', True),
+                'options': {
+                    'registries': {
+                        'type': 'list_dict',
+                        'help': '''
+List of custom registries in v2 format.
+=======================================
 
-                        Add by specifying B{location}, B{prefix}, and B{insecure}. e.g.,
+Add by specifying B{location}, B{prefix}, and B{insecure}. e.g.,
 
-                          add location=172.17.0.1:5000/docker.io prefix=docker.io insecure=true
-                        ''',
-                'params_spec': {
-                    'location': {
-                        'required': True
+add location=172.17.0.1:5000/docker.io prefix=docker.io insecure=true
+''',
+                        'params_spec': {
+                            'location': {
+                                'required': True
+                            },
+                            'prefix': {},
+                            'insecure': {
+                                'validator': BooleanStringValidator,
+                                'transformer': BooleanStringTransformer
+                            },
+                            'blocked': {
+                                'validator': BooleanStringValidator,
+                                'transformer': BooleanStringTransformer
+                            }
+                        },
+                        'handler': PillarHandler('ceph-salt:container:registries')
                     },
-                    'prefix': {},
-                    'insecure': {
-                        'validator': BooleanStringValidator,
-                        'transformer': BooleanStringTransformer
-                    },
-                    'blocked': {
-                        'validator': BooleanStringValidator,
-                        'transformer': BooleanStringTransformer
-                    }
-                },
-                'handler': PillarHandler('ceph-salt:container:registries')
+                }
             }
         }
     },

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -115,8 +115,13 @@ class ConfigShellTest(SaltMockTestCase):
                                'ceph-salt:container:images:ceph',
                                'myvalue')
 
-    def test_containers_registries(self):
-        self.assertListDictOption('/containers/registries',
+    def test_containers_registries_conf(self):
+        self.assertFlagOption('/containers/registries_conf',
+                              'ceph-salt:container:registries_enabled',
+                              reset_supported=False)
+
+    def test_containers_registries_conf_registries(self):
+        self.assertListDictOption('/containers/registries_conf/registries',
                                   'ceph-salt:container:registries',
                                   ['location=172.17.0.1:5000 insecure=false',
                                    ('location=192.168.0.1:8080/docker.io prefix=docker.io'
@@ -246,6 +251,9 @@ class ConfigShellTest(SaltMockTestCase):
 
         self.assertTrue(run_export(False))
         self.assertJsonInSysOut({
+            'container': {
+                'registries_enabled': True
+            },
             'dashboard': {
                 'username': 'admin',
                 'password': PillarManager.get('ceph-salt:dashboard:password'),


### PR DESCRIPTION
This PR is an alternative to https://github.com/ceph/ceph-salt/pull/214

---

With this PR, users will be able to control if `/etc/containers/registries.conf` should be managed by `ceph-salt` or not.

By default, `/etc/containers/registries.conf` management is enabled, but can be disabled by:
```
# ceph-salt config /containers/registries_conf disable
```

(Note that we had to move `/containers/registries` to `/containers/registries_conf/registries`)

Signed-off-by: Ricardo Marques <rimarques@suse.com>
