### PR TITLE
Don't log scrollbar info when rendering scrollbar

### DIFF
--- a/ceph_salt/apply.py
+++ b/ceph_salt/apply.py
@@ -189,8 +189,6 @@ class CursesScreen:
         current_pos = round((self.body_pos * self.body_height) / current_row)
         if current_pos >= self.body_height:
             current_pos = self.body_height - 1
-        logger.info("scroll_size=%s body_height=%s current_row=%s current_pos=%s body_pos=%s",
-                    scroll_size, self.body_height, current_row, current_pos, self.body_pos)
         for i in range(0, scroll_size):
             self._write(self.scrollbar, current_pos + i, 0, "▐", CursesScreen.COLOR_MARKER, False,
                         False, False, 1)


### PR DESCRIPTION
If there's more lines than will fit in the current terminal (say there's lots of hosts, or you've expanded everything), a scrollbar is rendered.  This happens continually, resulting in endlessly repeating log messages:

```
[ceph_salt.apply] scroll_size=6 body_height=12 current_row=26 current_pos=0 body_pos=0
[ceph_salt.apply] scroll_size=6 body_height=12 current_row=26 current_pos=0 body_pos=0
...
```

I ended up with 37 megabytes of this in /var/log/ceph-salt.log, so thought maybe it's best to not log this information.

I wonder if it's also safe to remove "initializing curses screen", "current terminal size: ...", "initializing scrollable pad", etc. but at least those messages only show up when you resize the window, rather than continuously.

Signed-off-by: Tim Serong <tserong@suse.com>