### PR TITLE
configshell: Handle execution errors on command line

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -1276,7 +1276,11 @@ def run_config_cmdline(cmdline):
     shell = CephSaltConfigShell()
     generate_config_shell_tree(shell)
     logger.info("running command: %s", cmdline)
-    shell.run_cmdline(cmdline)
+    try:
+        shell.run_cmdline(cmdline)
+    except (configshell.ExecutionError, CephSaltException) as ex:
+        logger.exception(ex)
+        PP.pl_red(ex)
     return True
 
 


### PR DESCRIPTION
Similar to https://github.com/ceph/ceph-salt/pull/126, but for running individual commands, so instead of a backtrace we get a nice error e.g.:

```
master:~ # ceph-salt config foo
Command not found foo
```

Signed-off-by: Tim Serong <tserong@suse.com>