### PR TITLE
Use `ceph orch status` as check for configuring ssh orchestrator

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
@@ -70,8 +70,7 @@ configure ssh orchestrator:
         ceph config-key set mgr/cephadm/ssh_identity_pub -i /tmp/ceph-salt-ssh-id_rsa.pub
         ceph mgr module enable cephadm && \
         ceph orch set backend cephadm
-    - onchanges:
-      - cmd: run cephadm bootstrap
+    - unless: "ceph orch status 2>&1 | grep -q 'Backend: cephadm'"
     - failhard: True
 
 {{ macros.end_step('Configure cephadm MGR module') }}


### PR DESCRIPTION
Previously, orchestrator configuration would only happen if `cephadm bootstrap` was actually executed (the "onchanges" condition).  This creates a problem for upgrades from DeepSea to ceph-salt, where `cephadm bootstrap` will never run (because /etc/ceph/ceph.conf and /etc/ceph/ceph.client.admin.keyring already exist), which in turn means the orchestrator configuration never happens.

By replacing "onchanges" with "unless: ceph orch status...", we decouple these two steps, so the orchestrator configuration will happen in any case where the backend is not already set to cephadm.

Signed-off-by: Tim Serong <tserong@suse.com>