### PR TITLE
container: make step/stage descriptions more descriptive

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/container.sls
+++ b/ceph-salt-formula/salt/ceph-salt/container.sls
@@ -1,8 +1,8 @@
 {% import 'macros.yml' as macros %}
 
-{{ macros.begin_stage('Container environment') }}
+{{ macros.begin_stage('Set up container environment') }}
 
-{{ macros.begin_step('Configure registries') }}
+{{ macros.begin_step('Configure container image registries') }}
 
 /etc/containers/registries.conf:
   file.managed:
@@ -15,6 +15,6 @@
     - backup: minion
     - failhard: True
 
-{{ macros.end_step('Configure registries') }}
+{{ macros.end_step('Configure container image registries') }}
 
-{{ macros.end_stage('Container environment') }}
+{{ macros.end_stage('Set up container environment') }}


### PR DESCRIPTION
The names of all steps and stages are constructed around a verb in
imperative mood.

The purpose of this step/stage, as far as I can tell, is to
create/populate /etc/containers-registries.conf which, according to

    man 5 containers-registries.conf

is "a system-wide configuration file for container image registries."

Signed-off-by: Nathan Cutler <ncutler@suse.com>