### PR TITLE
Allow to re-apply config

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/ceph-admin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/ceph-admin.sls
@@ -8,4 +8,15 @@ copy ceph.conf and keyring from an admin node:
     - failhard: True
 {{ macros.end_stage('Ensure ceph.conf and keyring are present') }}
 
+{{ macros.begin_stage('Ensure cephadm MGR module is configured') }}
+
+configure cephadm mgr module:
+  cmd.run:
+    - name: |
+        ceph config-key set mgr/cephadm/ssh_identity_key -i /tmp/ceph-salt-ssh-id_rsa
+        ceph config-key set mgr/cephadm/ssh_identity_pub -i /tmp/ceph-salt-ssh-id_rsa.pub
+    - failhard: True
+
+{{ macros.end_stage('Ensure cephadm MGR module is configured') }}
+
 {% endif %}

--- a/ceph_salt/apply.py
+++ b/ceph_salt/apply.py
@@ -12,7 +12,7 @@ from typing import Dict, List
 
 import yaml
 
-from .core import CephNode, CephNodeManager
+from .core import CephNodeManager
 from .exceptions import MinionDoesNotExistInConfiguration, ValidationException
 from .salt_event import EventListener, SaltEventProcessor
 from .salt_utils import SaltClient, GrainsManager, CephOrch, PillarManager
@@ -1279,25 +1279,13 @@ class CephSaltExecutor:
                       "all minions at the same time to bootstrap a new Ceph cluster: "
                       "\"ceph-salt apply\"")
             return 6
-        # day 2, but minion_id not specified
-        if deployed and minion_id is None:
-            logger.error("Ceph cluster already deployed and minion_id not provided")
-            PP.pl_red("Ceph cluster is already deployed, please apply the config to a "
-                      "single minion at a time: \"ceph-salt apply <minion_id>\"")
-            return 7
-        # day 2, but minion_id already managed by cephadm
-        if deployed and minion_id is not None:
+        # Invalid minion_id
+        if minion_id is not None:
             salt_minions = CephNodeManager.list_all_minions()
             if minion_id not in salt_minions:
                 logger.error("cannot find minion: %s", minion_id)
                 PP.pl_red("Cannot find minion '{}'".format(minion_id))
-                return 8
-            node = CephNode(minion_id)
-            for host in host_ls:
-                if node.hostname == host['hostname']:
-                    logger.error("minion_id already managed by cephadm: %s", minion_id)
-                    PP.pl_red("Minion '{}' is already managed by cephadm".format(minion_id))
-                    return 9
+                return 7
         return 0
 
     @staticmethod

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -343,26 +343,10 @@ class ApplyTest(SaltMockTestCase):
         self.assertEqual(CephSaltExecutor.check_cluster('node1.ceph.com', []), 6)
         self.fs.remove_object(os.path.join(self.states_fs_path(), 'ceph-salt.sls'))
 
-    def test_check_cluster_day2_without_minion(self):
-        self.fs.create_file(os.path.join(self.states_fs_path(), 'ceph-salt.sls'))
-        host_ls_result = [{'hostname': 'node1.ceph.com'}]
-        CephOrchMock.host_ls_result = host_ls_result
-        self.assertEqual(CephSaltExecutor.check_cluster(None, host_ls_result), 7)
-        CephOrchMock.host_ls_result = []
-        self.fs.remove_object(os.path.join(self.states_fs_path(), 'ceph-salt.sls'))
-
-    def test_check_cluster_day2_with_minion_not_found(self):
+    def test_check_minion_not_found(self):
         self.fs.create_file(os.path.join(self.states_fs_path(), 'ceph-salt.sls'))
         host_ls_result = [{'hostname': 'node1'}]
         CephOrchMock.host_ls_result = host_ls_result
-        self.assertEqual(CephSaltExecutor.check_cluster('node9.ceph.com', host_ls_result), 8)
-        CephOrchMock.host_ls_result = []
-        self.fs.remove_object(os.path.join(self.states_fs_path(), 'ceph-salt.sls'))
-
-    def test_check_cluster_day2_with_minion_deployed(self):
-        self.fs.create_file(os.path.join(self.states_fs_path(), 'ceph-salt.sls'))
-        host_ls_result = [{'hostname': 'node1'}]
-        CephOrchMock.host_ls_result = host_ls_result
-        self.assertEqual(CephSaltExecutor.check_cluster('node1.ceph.com', host_ls_result), 9)
+        self.assertEqual(CephSaltExecutor.check_cluster('node9.ceph.com', host_ls_result), 7)
         CephOrchMock.host_ls_result = []
         self.fs.remove_object(os.path.join(self.states_fs_path(), 'ceph-salt.sls'))


### PR DESCRIPTION
With this PR user will be able to run `ceph-salt apply` and `ceph-salt apply <minion_id>` even if minions are already managed by `cephadm`.

Note that `ceph-salt` will not automatically reboot nodes where ceph containers are running to avoid unexpected "downtimes", the following message is displayed in this case: `Running ceph containers found, please reboot manually`

Fixes: https://github.com/ceph/ceph-salt/issues/173
Fixes: https://github.com/ceph/ceph-salt/issues/176

Signed-off-by: Ricardo Marques <rimarques@suse.com>