### PR TITLE
[DNM] Disable time sync

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/init.sls
@@ -7,7 +7,6 @@ include:
     - .container
     - .apparmor
     - .time-prep
-    - .time-sync
     - .cephtools
     - .provision-end
     - .cephbootstrap


### PR DESCRIPTION
We are facing a salt timeout/overloaded issue when deploying large clusters (>=104 nodes).

This PR is just to test if disabling time sync fixes the issue.

Signed-off-by: Ricardo Marques <rimarques@suse.com>