### PR TITLE
[DNM] Optionally deploy monitoring stack on bootstrap node

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
@@ -44,7 +44,9 @@ run cephadm bootstrap:
 {%- endif %}
                 --output-keyring /etc/ceph/ceph.client.admin.keyring \
                 --output-config /etc/ceph/ceph.conf \
+{%- if not pillar['ceph-salt']['bootstrap_node_monitoring_stack'] %}
                 --skip-monitoring-stack \
+{%- endif %}
                 --skip-prepare-host \
                 --skip-pull \
                 --skip-ssh \

--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -497,6 +497,12 @@ add location=172.17.0.1:5000/docker.io prefix=docker.io insecure=true
                 'help': 'Bootstrap Mon IP',
                 'handler': PillarHandler('ceph-salt:bootstrap_mon_ip')
             },
+            'monitoring_stack': {
+                'type': 'flag',
+                'help': ('Whether to deploy the whole monitoring stack on the '
+                         'bootstrap node'),
+                'handler': PillarHandler('ceph-salt:bootstrap_node_monitoring_stack', False)
+            },
         }
     },
     'ssh': {

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -251,6 +251,7 @@ class ConfigShellTest(SaltMockTestCase):
 
         self.assertTrue(run_export(False))
         self.assertJsonInSysOut({
+            'bootstrap_node_monitoring_stack': False,
             'container': {
                 'registries_enabled': True
             },


### PR DESCRIPTION
d59c8eb9d1e96aa9d7424e0a236471019d84ae6e added "--skip-monitoring-stack"
to the "cephadm bootstrap" command, which had the effect of
unconditionally removing the user's access to this cephadm feature.

There might be scenarios where the user would want to deploy the
monitoring stack on the bootstrap node, so add a configurable for it.

Fixes: https://github.com/ceph/ceph-salt/issues/274
Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

To Do:

- [ ] add configurables and other code necessary for including monitor container image paths in configshell "container->images->grafana"
- [ ] `cephadm bootstrap` supports specifying alternate monitoring container image paths
