### PR TITLE
Optimize "ceph_orch.wait_for_admin_host" state

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_orch.py
+++ b/ceph-salt-formula/salt/_modules/ceph_orch.py
@@ -2,14 +2,11 @@
 import json
 
 def configured():
-    ret = __salt__['cmd.run_all']("sh -c 'type ceph'")
-    if ret['retcode'] != 0:
-        return False
     if not __salt__['file.file_exists']("/etc/ceph/ceph.conf"):
         return False
     if not __salt__['file.file_exists']("/etc/ceph/ceph.client.admin.keyring"):
         return False
-    ret = __salt__['cmd.run_all']("ceph orch status")
+    ret = __salt__['cmd.run_all']("timeout 60 ceph orch status")
     if ret['retcode'] != 0:
         return False
     return True

--- a/ceph-salt-formula/salt/_states/ceph_orch.py
+++ b/ceph-salt-formula/salt/_states/ceph_orch.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-import json
 import time
 
 
@@ -25,14 +24,14 @@ def wait_for_admin_host(name, timeout=1800):
             if provisioned:
                 configured_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
                                                         "-i /tmp/ceph-salt-ssh-id_rsa root@{} "
-                                                        "'salt-call ceph_orch.configured "
-                                                        "--out=json --out-indent=-1'".format(
+                                                        "'if [[ -f /etc/ceph/ceph.conf "
+                                                        "&& -f /etc/ceph/ceph.client.admin.keyring ]]; "
+                                                        "then timeout 60 ceph orch status; "
+                                                        "else (exit 1); fi'".format(
                                                             admin_host))
                 if configured_ret['retcode'] == 0:
-                    configured = json.loads(configured_ret['stdout'])['local']
-                    if configured:
-                        configured_admin_host = admin_host
-                        break
+                    configured_admin_host = admin_host
+                    break
     __salt__['grains.set']('ceph-salt:execution:admin_host', configured_admin_host)
     ret['result'] = True
     return ret


### PR DESCRIPTION
Deployment of large clusters is failing with the following error, which is caused by multiple `salt-call` executions in parallel on `admin` minions:

```
2020-06-23 12:32:13,238 [salt.minion      :2011][WARNING ][30636] The minion failed to return the job information for job 20200623123149042477. This is often due to the master being shut down or overloaded. If the master is running, consider increasing the worker_threads value.
```

This PR optimize `ceph_orch.wait_for_admin_host` state, which will fix the error above.

1) Do not use `salt-call` for better performance.

2) Also, use timeout to guarantee that `ceph orch status` will not hang.

Signed-off-by: Ricardo Marques <rimarques@suse.com>