### PR TITLE
Support registry authentication

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/cleanup.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cleanup.sls
@@ -7,3 +7,16 @@ remove ceph-salt-ssh-id_rsa.pub:
   file.absent:
     - name: /tmp/ceph-salt-ssh-id_rsa.pub
     - failhard: True
+
+{% set registries = pillar['ceph-salt'].get('container', {}).get('auth', []) -%}
+{%- for reg in registries %}
+remove ceph-salt-registry-password-{{loop.index}}:
+  file.absent:
+    - name: /tmp/ceph-salt-registry-password-{{loop.index}}
+    - failhard: True
+logout from registry {{loop.index}}:
+  cmd.run:
+    - name: |
+        podman logout {{reg.registry}}
+    - failhard: True
+{%- endfor %}

--- a/ceph-salt-formula/salt/ceph-salt/container.sls
+++ b/ceph-salt-formula/salt/ceph-salt/container.sls
@@ -1,8 +1,8 @@
 {% import 'macros.yml' as macros %}
 
-{% if pillar['ceph-salt']['container']['registries_enabled'] %}
-
 {{ macros.begin_stage('Set up container environment') }}
+
+{% if pillar['ceph-salt']['container']['registries_enabled'] %}
 
 {{ macros.begin_step('Configure container image registries') }}
 
@@ -19,6 +19,34 @@
 
 {{ macros.end_step('Configure container image registries') }}
 
-{{ macros.end_stage('Set up container environment') }}
-
 {% endif %}
+
+{{ macros.begin_step('Login into registries') }}
+
+{% set registries = pillar['ceph-salt'].get('container', {}).get('auth', []) -%}
+{%- for reg in registries %}
+create ceph-salt-registry-password-{{loop.index}}:
+  file.managed:
+    - name: /tmp/ceph-salt-registry-password-{{loop.index}}
+    - user: root
+    - group: root
+    - mode: '0600'
+    - contents_pillar: ceph-salt:container:auth:{{loop.index - 1}}:password
+    - failhard: True
+
+login into registry {{loop.index}}:
+  cmd.run:
+    - name: |
+        podman login \
+{%- if 'tls_verify' in reg %}
+        --tls-verify={{reg.tls_verify}} \
+{%- endif %}
+        -u={{reg.username}} \
+        --password-stdin < /tmp/ceph-salt-registry-password-{{loop.index}} \
+        {{reg.registry}}
+    - failhard: True
+{%- endfor %}
+
+{{ macros.end_step('Login into registries') }}
+
+{{ macros.end_stage('Set up container environment') }}

--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -376,6 +376,39 @@ CEPH_SALT_OPTIONS = {
                 for deployment.
                 ''',
         'options': {
+            'auth': {
+                'type': 'group',
+                'help': "Registry autentications",
+                'options': {
+                    'registries': {
+                        'type': 'list_dict',
+                        'help': '''
+List of registry authentications.
+=======================================
+
+Add by specifying B{registry}, B{username}, B{password}, and B{tls_verify}. e.g.,
+
+add registry=172.17.0.1:5000 username=testuser password=testpassword tls_verify=false
+''',
+                        'params_spec': {
+                            'registry': {
+                                'required': True
+                            },
+                            'username': {
+                                'required': True
+                            },
+                            'password': {
+                                'required': True
+                            },
+                            'tls_verify': {
+                                'validator': BooleanStringValidator,
+                                'transformer': BooleanStringTransformer
+                            },
+                        },
+                        'handler': PillarHandler('ceph-salt:container:auth')
+                    }
+                }
+            },
             'images': {
                 'type': 'group',
                 'help': "Container images paths",

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -120,6 +120,30 @@ class ConfigShellTest(SaltMockTestCase):
                               'ceph-salt:container:registries_enabled',
                               reset_supported=False)
 
+    def test_containers_auth_registries(self):
+        self.assertListDictOption('/containers/auth/registries',
+                                  'ceph-salt:container:auth',
+                                  [('registry=172.17.0.1:5000 '
+                                    'username=testuser '
+                                    'password=testpassword '
+                                    'tls_verify=false'),
+                                   ('registry=192.168.0.1:443 '
+                                    'username=testuser2 '
+                                    'password=testpassword2')],
+                                  [
+                                      {
+                                          'registry': '172.17.0.1:5000',
+                                          'username': 'testuser',
+                                          'password': 'testpassword',
+                                          'tls_verify': False
+                                      },
+                                      {
+                                          'registry': '192.168.0.1:443',
+                                          'username': 'testuser2',
+                                          'password': 'testpassword2'
+                                      }
+                                  ])
+
     def test_containers_registries_conf_registries(self):
         self.assertListDictOption('/containers/registries_conf/registries',
                                   'ceph-salt:container:registries',


### PR DESCRIPTION
It's now possible to provide registry credentials so `ceph-salt` can pull images from registries that require authentication.

## How to configure a local registry that requires authentication

Create authentication file:
```
# mkdir -p auth
# htpasswd -Bbn testuser testpassword > auth/htpasswd
```

Start the registry with basic authentication:
```
podman run -d \
 --restart=always \
 --name registry \
 -p 5000:5000 \
-v "$(pwd)"/auth:/auth \
-e "REGISTRY_AUTH=htpasswd" \
-e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
-e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
 registry:2
```

Login (adapt IP address):
```
podman login --tls-verify=false -u testuser -p testpassword 192.168.1.102:5000
```

Mirror container images to the local registry (adapt IP address):
```
skopeo copy \
 --dest-tls-verify=false \
 docker://registry.opensuse.org/filesystems/ceph/octopus/upstream/images/ceph/ceph \
 docker://192.168.1.102:5000/registry.opensuse.org/filesystems/ceph/octopus/upstream/images/ceph/ceph
```

Logout (adapt IP address):
```
podman logout 192.168.1.102:5000
```

## How set registry credentials in ceph-salt

Configure container settings (adapt IP address):
```
ceph-salt config /containers/images/ceph set registry.opensuse.org/filesystems/ceph/octopus/upstream/images/ceph/ceph
 
ceph-salt config /containers/registries_conf/registries \
 add prefix=registry.opensuse.org \
 location=192.168.1.102:5000/registry.opensuse.org \
 insecure=true
 
ceph-salt config /containers/auth/registries \
  add registry=192.168.1.102:5000 \
  username=testuser \
  password=testpassword \
  tls_verify=false
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>