### PR TITLE
Fix log location message

### DIFF
--- a/ceph_salt/__init__.py
+++ b/ceph_salt/__init__.py
@@ -9,44 +9,12 @@ import pkg_resources
 
 from .config_shell import run_config_cmdline, run_config_shell, run_status, run_export, run_import
 from .exceptions import CephSaltException
+from .logging_utils import LoggingUtil
 from .terminal_utils import check_root_privileges, PrettyPrinter as PP
 from .apply import CephSaltExecutor
 
 
 logger = logging.getLogger(__name__)
-
-
-def _setup_logging(log_level, log_file):
-    """
-    Logging configuration
-    """
-    if log_level == "silent":
-        return
-
-    logging.config.dictConfig({
-        'version': 1,
-        'disable_existing_loggers': False,
-        'formatters': {
-            'standard': {
-                'format': '%(asctime)s [%(levelname)s] [%(name)s] %(message)s'
-            },
-        },
-        'handlers': {
-            'file': {
-                'level': log_level.upper(),
-                'filename': log_file,
-                'class': 'logging.FileHandler',
-                'formatter': 'standard'
-            },
-        },
-        'loggers': {
-            '': {
-                'handlers': ['file'],
-                'level': log_level.upper(),
-                'propagate': True,
-            }
-        }
-    })
 
 
 def ceph_salt_main():
@@ -69,7 +37,7 @@ def ceph_salt_main():
 @click.version_option(pkg_resources.get_distribution('ceph-salt'), message="%(version)s")
 @check_root_privileges
 def cli(log_level, log_file):
-    _setup_logging(log_level, log_file)
+    LoggingUtil.setup_logging(log_level, log_file)
 
 
 @cli.command(name='config')

--- a/ceph_salt/apply.py
+++ b/ceph_salt/apply.py
@@ -14,6 +14,7 @@ import yaml
 
 from .core import CephNodeManager
 from .exceptions import MinionDoesNotExistInConfiguration, ValidationException
+from .logging_utils import LoggingUtil
 from .salt_event import EventListener, SaltEventProcessor
 from .salt_utils import SaltClient, GrainsManager, CephOrch, PillarManager
 from .terminal_utils import PrettyPrinter as PP
@@ -1173,9 +1174,9 @@ class CursesRenderer(Renderer, ScreenKeyListener):
         self.loading.stop()
         if has_failed:
             PP.println("An error occurred in the UI, please check "
-                       "'/var/log/ceph-salt.log' for further details.")
+                       "'{}' for further details.".format(LoggingUtil.log_file))
         else:
-            PP.println("Finished. Log file may be found at '/var/log/ceph-salt.log'.")
+            PP.println("Finished. Log file may be found at '{}'.".format(LoggingUtil.log_file))
 
 
 class TerminalRenderer(Renderer):

--- a/ceph_salt/logging_utils.py
+++ b/ceph_salt/logging_utils.py
@@ -1,0 +1,39 @@
+import logging
+
+
+class LoggingUtil:
+    log_file = None
+
+    @classmethod
+    def setup_logging(cls, log_level, log_file):
+        """
+        Logging configuration
+        """
+        cls.log_file = log_file
+        if log_level == "silent":
+            return
+
+        logging.config.dictConfig({
+            'version': 1,
+            'disable_existing_loggers': False,
+            'formatters': {
+                'standard': {
+                    'format': '%(asctime)s [%(levelname)s] [%(name)s] %(message)s'
+                },
+            },
+            'handlers': {
+                'file': {
+                    'level': log_level.upper(),
+                    'filename': log_file,
+                    'class': 'logging.FileHandler',
+                    'formatter': 'standard'
+                },
+            },
+            'loggers': {
+                '': {
+                    'handlers': ['file'],
+                    'level': log_level.upper(),
+                    'propagate': True,
+                }
+            }
+        })


### PR DESCRIPTION
ATM, `ceph-salt apply` is always reporting the same log file location, regardless of the usage of `--log-file` option, e.g.:

```
ceph-salt --log-file /var/log/my.log apply
....
Finished. Log file may be found at '/var/log/ceph-salt.log'.
```

In the example above, it should say `Finished. Log file may be found at /var/log/my.log'.`.


Signed-off-by: Ricardo Marques <rimarques@suse.com>