### PR TITLE
Check 'ceph orch status' output

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_orch.py
+++ b/ceph-salt-formula/salt/_modules/ceph_orch.py
@@ -6,10 +6,11 @@ def configured():
         return False
     if not __salt__['file.file_exists']("/etc/ceph/ceph.client.admin.keyring"):
         return False
-    ret = __salt__['cmd.run_all']("timeout 60 ceph orch status")
-    if ret['retcode'] != 0:
+    status_ret = __salt__['cmd.run_all']("timeout 60 ceph orch status --format=json")
+    if status_ret['retcode'] != 0:
         return False
-    return True
+    status = json.loads(status_ret['stdout'])
+    return status.get('available', False)
 
 def host_ls():
     ret = __salt__['cmd.run']("ceph orch host ls --format=json")

--- a/ceph-salt-formula/salt/_states/ceph_orch.py
+++ b/ceph-salt-formula/salt/_states/ceph_orch.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+import json
 import time
 
 
@@ -22,16 +23,18 @@ def wait_for_admin_host(name, timeout=1800):
             provisioned = __salt__['ceph_salt.get_remote_grain'](admin_host,
                                                                 'ceph-salt:execution:provisioned')
             if provisioned:
-                configured_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                                        "-i /tmp/ceph-salt-ssh-id_rsa root@{} "
-                                                        "'if [[ -f /etc/ceph/ceph.conf "
-                                                        "&& -f /etc/ceph/ceph.client.admin.keyring ]]; "
-                                                        "then timeout 60 ceph orch status; "
-                                                        "else (exit 1); fi'".format(
-                                                            admin_host))
-                if configured_ret['retcode'] == 0:
-                    configured_admin_host = admin_host
-                    break
+                status_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
+                                                     "-i /tmp/ceph-salt-ssh-id_rsa root@{} "
+                                                     "'if [[ -f /etc/ceph/ceph.conf "
+                                                     "&& -f /etc/ceph/ceph.client.admin.keyring ]]; "
+                                                     "then timeout 60 ceph orch status --format=json; "
+                                                     "else (exit 1); fi'".format(
+                                                         admin_host))
+                if status_ret['retcode'] == 0:
+                    status = json.loads(status_ret['stdout'])
+                    if status.get('available'):
+                        configured_admin_host = admin_host
+                        break
     __salt__['grains.set']('ceph-salt:execution:admin_host', configured_admin_host)
     ret['result'] = True
     return ret


### PR DESCRIPTION
~~**After https://github.com/ceph/ceph/pull/35805 is backported (https://github.com/ceph/ceph/pull/35898)**~~

--- 

Instead of simply rely on return code, we need to check if "available: true" is returned, because:

```
master:~ # ceph orch status --format=json

{"available": true, "backend": "cephadm"}
master:~ # echo $?
0

master:~ # ceph cephadm clear-key

master:~ # ceph orch status --format=json

{"available": false, "backend": "cephadm", "reason": "SSH keys not set. Use `ceph cephadm set-priv-key` and `ceph cephadm set-pub-key` or `ceph cephadm generate-key`"}

master:~ # echo $?
0
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>