### PR TITLE
Improve "no minions matched" message when adding/removing minions

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -1120,7 +1120,7 @@ class MinionsOptionNode(OptionNode):
         elif counter > 1:
             PP.pl_green('{} minions added.'.format(counter))
         elif not has_errors:
-            PP.pl_red('No minions matched "{}".'.format(minion_id))
+            PP.pl_red('No minions added.')
 
     def ui_command_remove(self, minion_id):
         matching = fnmatch.filter(self.value, minion_id)
@@ -1144,7 +1144,7 @@ class MinionsOptionNode(OptionNode):
         elif counter > 1:
             PP.pl_green('{} minions removed.'.format(counter))
         elif not has_errors:
-            PP.pl_red('No minions matched "{}".'.format(minion_id))
+            PP.pl_red('No minions removed.')
 
     # pylint: disable=unused-argument
     def ui_complete_add(self, parameters, text, current_param):


### PR DESCRIPTION
`No minions matched ...` message may be confusing when adding a minion that was already added:

```
master:~ # ceph-salt config /ceph_cluster/roles/cephadm add node2.pacific.test
Adding node2.pacific.test...
1 minion added.
master:~ # ceph-salt config /ceph_cluster/roles/cephadm add node2.pacific.test
No minions matched "node2.pacific.test".
```

For this reason, this PR changes that message to `No minions added/removed.`:

```
master:~ # ceph-salt config /ceph_cluster/roles/cephadm add node2.pacific.test
Adding node2.pacific.test...
1 minion added.
master:~ # ceph-salt config /ceph_cluster/roles/cephadm add node2.pacific.test
No minions added.
```


Signed-off-by: Ricardo Marques <rimarques@suse.com>