### PR TITLE
Allow user to specify sudo ssh user

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -6,9 +6,11 @@ def get_remote_grain(host, grain):
     """
     Reads remote host grain by accessing '/etc/salt/grains' file directly.
     """
+    ssh_user = __pillar__['ceph-salt']['ssh']['user']
+    sudo = 'sudo ' if ssh_user != 'root' else ''
     ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                  "-i /tmp/ceph-salt-ssh-id_rsa root@{} "
-                                  "\"python3 - <<EOF\n"
+                                  "-i /tmp/ceph-salt-ssh-id_rsa {}@{} "
+                                  "\"{}python3 - <<EOF\n"
                                   "import json\n"
                                   "import salt.utils.data\n"
                                   "import yaml\n"
@@ -16,15 +18,18 @@ def get_remote_grain(host, grain):
                                   "    grains = yaml.full_load(grains_file)\n"
                                   "val = salt.utils.data.traverse_dict_and_list(grains, '{}')\n"
                                   "print(json.dumps({{'local': val}}))\n"
-                                  "EOF\"".format(host, grain))
+                                  "EOF\"".format(ssh_user, host, sudo, grain))
     if ret['retcode'] != 0:
         return None
     return json.loads(ret['stdout'])['local']
 
 def set_remote_grain(host, grain, value):
+    ssh_user = __pillar__['ceph-salt']['ssh']['user']
+    sudo = 'sudo ' if ssh_user != 'root' else ''
     return __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                   "-i /tmp/ceph-salt-ssh-id_rsa root@{} "
-                                   "'salt-call grains.set {} {}'".format(host, grain, value))
+                                   "-i /tmp/ceph-salt-ssh-id_rsa {}@{} "
+                                   "'{}salt-call grains.set {} {}'".format(ssh_user, host, sudo,
+                                                                           grain, value))
 
 def probe_ntp(ahost):
     import ntplib

--- a/ceph-salt-formula/salt/_states/ceph_orch.py
+++ b/ceph-salt-formula/salt/_states/ceph_orch.py
@@ -23,18 +23,23 @@ def wait_for_admin_host(name, timeout=1800):
             provisioned = __salt__['ceph_salt.get_remote_grain'](admin_host,
                                                                 'ceph-salt:execution:provisioned')
             if provisioned:
+                ssh_user = __pillar__['ceph-salt']['ssh']['user']
+                sudo = 'sudo ' if ssh_user != 'root' else ''
                 status_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                                     "-i /tmp/ceph-salt-ssh-id_rsa root@{} "
+                                                     "-i /tmp/ceph-salt-ssh-id_rsa {}@{} "
                                                      "'if [[ -f /etc/ceph/ceph.conf "
                                                      "&& -f /etc/ceph/ceph.client.admin.keyring ]]; "
-                                                     "then timeout 60 ceph orch status --format=json; "
+                                                     "then timeout 60 {}ceph orch status --format=json; "
                                                      "else (exit 1); fi'".format(
-                                                         admin_host))
+                                                         ssh_user,
+                                                         admin_host,
+                                                         sudo))
                 if status_ret['retcode'] == 0:
                     status = json.loads(status_ret['stdout'])
                     if status.get('available'):
                         configured_admin_host = admin_host
                         break
+
     __salt__['grains.set']('ceph-salt:execution:admin_host', configured_admin_host)
     ret['result'] = True
     return ret
@@ -43,9 +48,12 @@ def wait_for_admin_host(name, timeout=1800):
 def add_host(name, host):
     ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
     admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
+    ssh_user = __pillar__['ceph-salt']['ssh']['user']
+    sudo = 'sudo ' if ssh_user != 'root' else ''
     cmd_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                      "-i /tmp/ceph-salt-ssh-id_rsa root@{} "
-                                      "'ceph orch host add {}'".format(admin_host, host))
+                                      "-i /tmp/ceph-salt-ssh-id_rsa {}@{} "
+                                      "'{}ceph orch host add {}'".format(ssh_user, admin_host,
+                                                                       sudo, host))
     if cmd_ret['retcode'] == 0:
         ret['result'] = True
     return ret
@@ -54,10 +62,13 @@ def add_host(name, host):
 def copy_ceph_conf_and_keyring(name):
     ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
     admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
-    cmd_ret = __salt__['cmd.run_all']("scp -o StrictHostKeyChecking=no "
-                                      "-i /tmp/ceph-salt-ssh-id_rsa "
-                                      "root@{}:/etc/ceph/{{ceph.conf,ceph.client.admin.keyring}} "
-                                      "/etc/ceph/".format(admin_host))
+    ssh_user = __pillar__['ceph-salt']['ssh']['user']
+    sudo = 'sudo ' if ssh_user != 'root' else ''
+    cmd_ret = __salt__['cmd.run_all']("{0}rsync --rsync-path='{0}rsync' "
+                                      "-e 'ssh -o StrictHostKeyChecking=no "
+                                      "-i /tmp/ceph-salt-ssh-id_rsa' "
+                                      "{1}@{2}:/etc/ceph/{{ceph.conf,ceph.client.admin.keyring}} "
+                                      "/etc/ceph/".format(sudo, ssh_user, admin_host))
     if cmd_ret['retcode'] == 0:
         ret['result'] = True
     return ret

--- a/ceph-salt-formula/salt/ceph-salt/ceph-admin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/ceph-admin.sls
@@ -10,11 +10,14 @@ copy ceph.conf and keyring from an admin node:
 
 {{ macros.begin_stage('Ensure cephadm MGR module is configured') }}
 
+{% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
+
 configure cephadm mgr module:
   cmd.run:
     - name: |
         ceph config-key set mgr/cephadm/ssh_identity_key -i /tmp/ceph-salt-ssh-id_rsa
         ceph config-key set mgr/cephadm/ssh_identity_pub -i /tmp/ceph-salt-ssh-id_rsa.pub
+        ceph cephadm set-user {{ ssh_user }}
     - failhard: True
 
 {{ macros.end_stage('Ensure cephadm MGR module is configured') }}

--- a/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephbootstrap.sls
@@ -30,6 +30,7 @@ wait for other minions:
 
 {% set dashboard_username = pillar['ceph-salt']['dashboard']['username'] %}
 {% set dashboard_password = pillar['ceph-salt']['dashboard']['password'] %}
+{% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
 
 run cephadm bootstrap:
   cmd.run:
@@ -39,6 +40,7 @@ run cephadm bootstrap:
                 --config /tmp/bootstrap-ceph.conf \
                 --initial-dashboard-user {{ dashboard_username }} \
                 --initial-dashboard-password {{ dashboard_password }} \
+                --ssh-user {{ ssh_user }} \
 {%- if not pillar['ceph-salt']['dashboard']['password_update_required'] %}
                 --dashboard-password-noupdate \
 {%- endif %}

--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -550,6 +550,10 @@ add location=172.17.0.1:5000/docker.io prefix=docker.io insecure=true
                 'help': "SSH RSA public key",
                 'handler': SshPublicKeyHandler()
             },
+            'user': {
+                'help': 'SSH user',
+                'handler': PillarHandler('ceph-salt:ssh:user', 'root')
+            },
         }
     },
     'time_server': {

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -47,6 +47,9 @@ def validate_config(host_ls):
                    "role".format(admin_minion)
 
     # ssh
+    user = PillarManager.get('ceph-salt:ssh:user')
+    if not user:
+        return "No SSH user specified in config"
     priv_key = PillarManager.get('ceph-salt:ssh:private_key')
     if not priv_key:
         return "No SSH private key specified in config"

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -228,6 +228,12 @@ class ConfigShellTest(SaltMockTestCase):
                                 'ceph-salt:ssh:public_key',
                                 'mypublickey')
 
+    def test_ssh_user(self):
+        self.assertValueOption('/ssh/user',
+                               'ceph-salt:ssh:user',
+                               'myuser',
+                               'root')
+
     def test_time_server(self):
         self.assertFlagOption('/time_server',
                               'ceph-salt:time_server:enabled',
@@ -287,6 +293,9 @@ class ConfigShellTest(SaltMockTestCase):
                 'all': ['node1.ceph.com', 'node2.ceph.com'],
                 'admin': ['node1.ceph.com'],
                 'cephadm': ['node1.ceph.com', 'node2.ceph.com']
+            },
+            'ssh': {
+                'user': 'root'
             },
             'time_server': {
                 'enabled': True,

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -24,6 +24,10 @@ class ValidateConfigTest(SaltMockTestCase):
         self.assertEqual(validate_config([]), "Bootstrap minion must be 'Admin'")
         self.assertEqual(validate_config([{'hostname': 'node1'}]), None)
 
+    def test_ssh_no_user(self):
+        PillarManager.reset('ceph-salt:ssh:user')
+        self.assertEqual(validate_config([]), "No SSH user specified in config")
+
     def test_ssh_no_private_key(self):
         PillarManager.reset('ceph-salt:ssh:private_key')
         self.assertEqual(validate_config([]), "No SSH private key specified in config")
@@ -199,6 +203,7 @@ SCzirUzUKN2oge2WieNI7MQ=
         PillarManager.set('ceph-salt:updates:enabled', True)
         PillarManager.set('ceph-salt:updates:reboot', True)
         PillarManager.set('ceph-salt:container:images:ceph', 'docker.io/ceph/daemon-base:latest')
+        PillarManager.set('ceph-salt:ssh:user', 'root')
         PillarManager.set('ceph-salt:ssh:public_key', """ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ\
 ClF4wYDBN6wC9Amp4xouZTDbOqZdkXxUezgbFrG1Nd+YtK7rF3sMdcE7ypKWkxwq3a/ZdWxnlAgQaCq2onXVo02/HhXrkaOf\
 fH2GKzhEIw6sW0FnZ+y6XpBh6nvlD87mD8mrQbnhsjFjX+odS8gmNJOZOBxHdeWy86PHUesjttAUYwi42fWB6LkJrz74nbkp\


### PR DESCRIPTION
~~**After https://github.com/ceph/ceph-salt/pull/270**~~
~~**After https://github.com/ceph/ceph/pull/35606 is backported (https://github.com/ceph/ceph/pull/35898)**~~

---

With this PR, users will be able to specify a non-root user to be used on SSH connections (by default, `root` user is used):

```
master:~ # ceph-salt config /ssh/user set myuser
Value set.

master:~ # ceph-salt config /ssh ls
o- ssh .......................................................................................... [Key Pair set]
  o- private_key ............................................. [30:6a:cf:52:4f:1d:a2:b4:cd:8d:5f:a4:4d:51:45:4b]
  o- public_key .............................................. [30:6a:cf:52:4f:1d:a2:b4:cd:8d:5f:a4:4d:51:45:4b]
  o- user ............................................................................................. [myuser]
```

