### PR TITLE
Enable 'ceph.conf' management by cephadm

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Those minions will be Ceph nodes controlled by cephadm:
 /ceph_cluster/roles/cephadm add *
 ```
 
-And which of them will have "ceph.conf" and "keyring" installed:
+And which of them will have admin "keyring" installed:
 
 ```
 /ceph_cluster/roles/admin add *

--- a/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
@@ -16,6 +16,7 @@ configure cephadm mgr module:
 {%- if auth %}
         ceph cephadm registry-login -i /tmp/ceph-salt-registry-json
 {%- endif %}
+        ceph config set mgr mgr/cephadm/manage_etc_ceph_ceph_conf true
     - failhard: True
 
 {{ macros.end_stage('Ensure cephadm MGR module is configured') }}


### PR DESCRIPTION
~~**After ceph/ceph#35576 is backported (ceph/ceph#35898)**~~
~~**After https://github.com/ceph/ceph/pull/36286 is backported(https://github.com/ceph/ceph/pull/36450)**~~

---

Since https://github.com/ceph/ceph/pull/35576 we can now rely on `cephadm` to keep `/etc/ceph/ceph.conf` file updated on all hosts, for instance, when MONs change.

Fixes: https://github.com/ceph/ceph-salt/issues/199

Signed-off-by: Ricardo Marques <rimarques@suse.com>