### PR TITLE
[DNM] Support non-ASCII chars

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -8,7 +8,16 @@ import random
 import string
 
 
-from pyparsing import alphanums, OneOrMore, Optional, Regex, Suppress, Word, QuotedString
+from pyparsing import (
+    alphanums,
+    alphas8bit,
+    OneOrMore,
+    Optional,
+    QuotedString,
+    Regex,
+    Suppress,
+    Word
+)
 
 import configshell_fb as configshell
 from configshell_fb.shell import locatedExpr
@@ -1219,7 +1228,8 @@ class CephSaltConfigShell(configshell.ConfigShell):
             '~/.ceph_salt_config_shell')
         # Grammar of the command line
         command = locatedExpr(Word(alphanums + '_'))('command')
-        var = QuotedString('"') | QuotedString("'") | Word(alphanums + '?;&*$!#,=_\+/.<>()~@:-%[]')
+        var = QuotedString('"') | QuotedString("'") | Word(
+            alphanums + alphas8bit + '?;&*$!#,=_\+/.<>()~@:-%[]')
         value = var
         keyword = Word(alphanums + '_\-')
         kparam = locatedExpr(keyword + Suppress('=') + Optional(value, default=''))('kparams*')

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -199,7 +199,7 @@ class ConfigShellTest(SaltMockTestCase):
     def test_cephadm_bootstrap_dashboard_username(self):
         self.assertValueOption('/cephadm_bootstrap/dashboard/username',
                                'ceph-salt:dashboard:username',
-                               'myusername',
+                               'myusernameö',
                                'admin')
 
     def test_cephadm_bootstrap_dashboard_ssl_certificate(self):


### PR DESCRIPTION
**After https://tracker.ceph.com/issues/46548**

-- 

Accented, tilded, umlauted, etc...

**alphas8bit** will include the following chars:
```
ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ
```

So, the following will now work:

```
master:~ # ceph-salt config /cephadm_bootstrap/dashboard/username set mööö
Value set.

master:~ # ceph-salt config /cephadm_bootstrap/dashboard/username ls
o- username ............................................................. [mööö]
```


Fixes: https://github.com/ceph/ceph-salt/issues/286

Signed-off-by: Ricardo Marques <rimarques@suse.com>