### PR TITLE
Optimize 'ceph-salt status'

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -1260,29 +1260,14 @@ base:
     return False
 
 
-def count_hosts(host_ls):
-    all_hostnames = [CephNode(minion_id).hostname for minion_id
-                     in PillarManager.get('ceph-salt:minions:all', [])]
-    deployed = []
-    not_managed = []
-    for host in host_ls:
-        if host['hostname'] in all_hostnames:
-            deployed.append(host)
-        else:
-            not_managed.append(host)
-    return (len(all_hostnames), len(deployed), len(not_managed))
-
-
 def run_status():
     if not check_config_prerequesites():
         return False
     status = {}
     result = True
     host_ls = CephOrch.host_ls()
-    ceph_salt_nodes, deployed_nodes, not_managed_nodes = count_hosts(host_ls)
-    status['hosts'] = '{}/{} managed by cephadm'.format(deployed_nodes, ceph_salt_nodes)
-    if not_managed_nodes:
-        status['hosts'] += ' ({} hosts not managed by cephsalt)'.format(not_managed_nodes)
+    all = PillarManager.get('ceph-salt:minions:all', [])
+    status['cluster'] = '{} minions, {} hosts managed by cephadm'.format(len(all), len(host_ls))
     error_msg = validate_config(host_ls)
     if error_msg:
         result = False
@@ -1291,7 +1276,7 @@ def run_status():
     else:
         status['config'] = PP.green("OK")
     for k, v in status.items():
-        PP.println('{}{}'.format('{}: '.format(k).ljust(8), v))
+        PP.println('{}{}'.format('{}: '.format(k).ljust(9), v))
     return result
 
 

--- a/ceph_salt/salt_utils.py
+++ b/ceph_salt/salt_utils.py
@@ -314,7 +314,7 @@ class CephOrch:
 
     @staticmethod
     def host_ls():
-        result = SaltClient.local().cmd('ceph-salt:member', 'ceph_orch.configured',
+        result = SaltClient.local().cmd('ceph-salt:roles:admin', 'ceph_orch.configured',
                                         tgt_type='grain')
         for minion, value in result.items():
             if value is True:


### PR DESCRIPTION
Getting the `hostname` of all hosts just to knows which of them are already managed by `cephadm` is an expensive operation, so we are now changing the information reported by `ceph-salt status` in order to avoid `grains.get hostname` calls.

# Before:

```
master:~ # ceph-salt status
hosts:  4/4 managed by cephadm
config: OK
```
This means that  we have 4 minions in our config (`ceph-salt config /ceph_cluster/minions ls`), and all of them are added to cephadm (`ceph orch host ls`).

# After:

```
master:~ # ceph-salt status
cluster: 4 minions, 4 hosts managed by cephadm
config:  OK
```
This means that we have 4 minions in our config (`ceph-salt config /ceph_cluster/minions ls`), and we have 4 hosts added to cephadm (`ceph orch host ls`).
Note that those 4 hosts are not necessarily the ones we have in our ceph-salt config.

# Performance improvement on a 31 nodes cluster, with 1 admin node:

Note that this PR also changes the way we try to find a minion to execute `cephadm host ls` command. We are now trying to execute it only on `admin` nodes, instead of iterating all minions.

Before: `ceph-salt status` -> `1m4.412s`
After: `ceph-salt status` -> `0m17.285s`


Fixes: https://github.com/ceph/ceph-salt/issues/231

Signed-off-by: Ricardo Marques <rimarques@suse.com>