### PR TITLE
Make use of cephadm for registry authentication

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
@@ -5,6 +5,7 @@
 {{ macros.begin_stage('Ensure cephadm MGR module is configured') }}
 
 {% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
+{% set auth = pillar['ceph-salt'].get('container', {}).get('auth', {}) %}
 
 configure cephadm mgr module:
   cmd.run:
@@ -12,6 +13,9 @@ configure cephadm mgr module:
         ceph cephadm set-priv-key -i /tmp/ceph-salt-ssh-id_rsa
         ceph cephadm set-pub-key -i /tmp/ceph-salt-ssh-id_rsa.pub
         ceph cephadm set-user {{ ssh_user }}
+{%- if auth %}
+        ceph cephadm registry-login -i /tmp/ceph-salt-registry-json
+{%- endif %}
     - failhard: True
 
 {{ macros.end_stage('Ensure cephadm MGR module is configured') }}

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -50,6 +50,7 @@ wait for other minions:
 {% set dashboard_username = pillar['ceph-salt']['dashboard']['username'] %}
 {% set dashboard_password = pillar['ceph-salt']['dashboard']['password'] %}
 {% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
+{% set auth = pillar['ceph-salt'].get('container', {}).get('auth', {}) %}
 
 {# --mon-ip is still required, even though we're also putting the Mon IP      #}
 {# directly in the placement YAML (see https://tracker.ceph.com/issues/46782) #}
@@ -68,6 +69,9 @@ run cephadm bootstrap:
                 --initial-dashboard-user {{ dashboard_username }} \
                 --output-config /etc/ceph/ceph.conf \
                 --output-keyring /etc/ceph/ceph.client.admin.keyring \
+{%- if auth %}
+                --registry-json /tmp/ceph-salt-registry-json \
+{%- endif %}
                 --skip-monitoring-stack \
                 --skip-prepare-host \
                 --skip-pull \

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
@@ -42,6 +42,37 @@ have cephadm check the host:
 
 {{ macros.end_step('Run "cephadm check-host"') }}
 
+{% set auth = pillar['ceph-salt'].get('container', {}).get('auth', {}) %}
+
+{% if auth %}
+
+{{ macros.begin_step('Login into registry') }}
+
+create ceph-salt-registry-json:
+  file.managed:
+    - name: /tmp/ceph-salt-registry-json
+    - source:
+        - salt://ceph-salt/files/registry-login-json.j2
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: '0600'
+    - backup: minion
+    - failhard: True
+
+login into registry:
+  cmd.run:
+    - name: |
+        cephadm registry-login \
+        --registry-url {{ auth.get('registry') }} \
+        --registry-username {{ auth.get('username') }} \
+        --registry-password {{ auth.get('password') }}
+    - failhard: True
+
+{{ macros.end_step('Login into registry') }}
+
+{% endif %}
+
 {{ macros.begin_step('Download ceph container image') }}
 download ceph container image:
   cmd.run:

--- a/ceph-salt-formula/salt/ceph-salt/apply/cleanup.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cleanup.sls
@@ -8,19 +8,7 @@ remove ceph-salt-ssh-id_rsa.pub:
     - name: /tmp/ceph-salt-ssh-id_rsa.pub
     - failhard: True
 
-remove ceph-salt-registry-password:
+remove ceph-salt-registry-json:
   file.absent:
-    - name: /tmp/ceph-salt-registry-password
+    - name: /tmp/ceph-salt-registry-json
     - failhard: True
-
-{% set auth = pillar['ceph-salt'].get('container', {}).get('auth', {}) %}
-
-{% if auth %}
-
-logout from registry:
-  cmd.run:
-    - name: |
-        podman logout {{ auth.get('registry') }}
-    - failhard: True
-
-{% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/apply/container.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/container.sls
@@ -21,32 +21,4 @@
 
 {% endif %}
 
-{% set auth = pillar['ceph-salt'].get('container', {}).get('auth', {}) %}
-
-{% if auth %}
-
-{{ macros.begin_step('Login into registry') }}
-
-create ceph-salt-registry-password:
-  file.managed:
-    - name: /tmp/ceph-salt-registry-password
-    - user: root
-    - group: root
-    - mode: '0600'
-    - contents_pillar: ceph-salt:container:auth:password
-    - failhard: True
-
-login into registry:
-  cmd.run:
-    - name: |
-        podman login \
-        -u={{ auth.get('username') }} \
-        --password-stdin < /tmp/ceph-salt-registry-password \
-        {{ auth.get('registry') }}
-    - failhard: True
-
-{{ macros.end_step('Login into registry') }}
-
-{% endif %}
-
 {{ macros.end_stage('Set up container environment') }}

--- a/ceph-salt-formula/salt/ceph-salt/files/registry-login-json.j2
+++ b/ceph-salt-formula/salt/ceph-salt/files/registry-login-json.j2
@@ -1,0 +1,6 @@
+{% set auth = pillar['ceph-salt'].get('container', {}).get('auth', {}) %}
+{
+"url": "{{ auth.get('registry') }}",
+"username": "{{ auth.get('username') }}",
+"password": "{{ auth.get('password') }}"
+}


### PR DESCRIPTION
~~**After https://github.com/ceph/ceph/pull/36012 is backported (https://github.com/ceph/ceph/pull/36450)**~~
~~**After https://github.com/ceph/ceph/pull/36375 is backported (https://github.com/ceph/ceph/pull/36450)**~~

---

Instead of using 'podman login' directly, 'ceph-salt' should use 'cephadm' to login into registry.

Signed-off-by: Ricardo Marques <rimarques@suse.com>