### PR TITLE
Set 'unqualified-search-registries' based on OS distro

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/files/registries.conf.j2
+++ b/ceph-salt-formula/salt/ceph-salt/files/registries.conf.j2
@@ -3,7 +3,11 @@
 # For more information on this configuration file, see containers-registries.conf(5)
 
 # An array of host[:port] registries to try when pulling an unqualified image, in order
+{% if grains.get('os_family') == 'Suse' and grains.get('osfullname') == 'SLES' %}
+unqualified-search-registries = ["registry.suse.com"]
+{% else %}
 unqualified-search-registries = ["docker.io"]
+{% endif %}
 
 {% for reg in registries %}
 [[registry]]


### PR DESCRIPTION
For SUSE distro, `registry.suse.com` should be used instead of `docker.io`.

Signed-off-by: Ricardo Marques <rimarques@suse.com>