### PR TITLE
Only allow authentication on a single registry

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/cleanup.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cleanup.sls
@@ -8,15 +8,19 @@ remove ceph-salt-ssh-id_rsa.pub:
     - name: /tmp/ceph-salt-ssh-id_rsa.pub
     - failhard: True
 
-{% set registries = pillar['ceph-salt'].get('container', {}).get('auth', []) -%}
-{%- for reg in registries %}
-remove ceph-salt-registry-password-{{loop.index}}:
+remove ceph-salt-registry-password:
   file.absent:
-    - name: /tmp/ceph-salt-registry-password-{{loop.index}}
+    - name: /tmp/ceph-salt-registry-password
     - failhard: True
-logout from registry {{loop.index}}:
+
+{% set auth = pillar['ceph-salt'].get('container', {}).get('auth', {}) %}
+
+{% if auth %}
+
+logout from registry:
   cmd.run:
     - name: |
-        podman logout {{reg.registry}}
+        podman logout {{ auth.get('registry') }}
     - failhard: True
-{%- endfor %}
+
+{% endif %}

--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -376,37 +376,22 @@ CEPH_SALT_OPTIONS = {
                 for deployment.
                 ''',
         'options': {
-            'auth': {
+            'registry_auth': {
                 'type': 'group',
                 'help': "Registry autentications",
                 'options': {
-                    'registries': {
-                        'type': 'list_dict',
-                        'help': '''
-List of registry authentications.
-=======================================
-
-Add by specifying B{registry}, B{username}, B{password}, and B{tls_verify}. e.g.,
-
-add registry=172.17.0.1:5000 username=testuser password=testpassword tls_verify=false
-''',
-                        'params_spec': {
-                            'registry': {
-                                'required': True
-                            },
-                            'username': {
-                                'required': True
-                            },
-                            'password': {
-                                'required': True
-                            },
-                            'tls_verify': {
-                                'validator': BooleanStringValidator,
-                                'transformer': BooleanStringTransformer
-                            },
-                        },
-                        'handler': PillarHandler('ceph-salt:container:auth')
-                    }
+                    'username': {
+                        'help': 'Username of account to login to on registry',
+                        'handler': PillarHandler('ceph-salt:container:auth:username')
+                    },
+                    'password': {
+                        'help': 'Password of account to login to on registry',
+                        'handler': PillarHandler('ceph-salt:container:auth:password')
+                    },
+                    'registry': {
+                        'help': 'URL of registry to login to',
+                        'handler': PillarHandler('ceph-salt:container:auth:registry')
+                    },
                 }
             },
             'images': {

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -85,7 +85,18 @@ def validate_config(host_ls):
             return 'No external time servers specified in config'
         if not time_server_is_minion and external_time_servers:
             return not_minion_err.format('external time servers')
+
+    # container
     ceph_container_image_path = PillarManager.get('ceph-salt:container:images:ceph')
     if not ceph_container_image_path:
         return "No Ceph container image path specified in config"
+    auth = PillarManager.get('ceph-salt:container:auth')
+    if auth:
+        username = auth.get('username')
+        password = auth.get('password')
+        registry = auth.get('registry')
+        if username or password or registry:
+            if not username or not password or not registry:
+                return "Registry auth configuration is incomplete"
+
     return None

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -120,29 +120,20 @@ class ConfigShellTest(SaltMockTestCase):
                               'ceph-salt:container:registries_enabled',
                               reset_supported=False)
 
-    def test_containers_auth_registries(self):
-        self.assertListDictOption('/containers/auth/registries',
-                                  'ceph-salt:container:auth',
-                                  [('registry=172.17.0.1:5000 '
-                                    'username=testuser '
-                                    'password=testpassword '
-                                    'tls_verify=false'),
-                                   ('registry=192.168.0.1:443 '
-                                    'username=testuser2 '
-                                    'password=testpassword2')],
-                                  [
-                                      {
-                                          'registry': '172.17.0.1:5000',
-                                          'username': 'testuser',
-                                          'password': 'testpassword',
-                                          'tls_verify': False
-                                      },
-                                      {
-                                          'registry': '192.168.0.1:443',
-                                          'username': 'testuser2',
-                                          'password': 'testpassword2'
-                                      }
-                                  ])
+    def test_containers_registry_auth_username(self):
+        self.assertValueOption('/containers/registry_auth/username',
+                               'ceph-salt:container:auth:username',
+                               'testuser')
+
+    def test_containers_registry_auth_password(self):
+        self.assertValueOption('/containers/registry_auth/password',
+                               'ceph-salt:container:auth:password',
+                               'testpassword')
+
+    def test_containers_registry_auth_registry(self):
+        self.assertValueOption('/containers/registry_auth/registry',
+                               'ceph-salt:container:auth:registry',
+                               '172.17.0.1:5000')
 
     def test_containers_registries_conf_registries(self):
         self.assertListDictOption('/containers/registries_conf/registries',

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -122,6 +122,14 @@ PBVw2pLCZsH5ol3VJ1/DETsGRMzFubFeTUNOC3MzhhG+V"""
         self.assertEqual(validate_config([]),
                          "Minion 'node3.ceph.com' has 'admin' role but not 'cephadm' role")
 
+    def test_incomplete_registry_auth(self):
+        PillarManager.set('ceph-salt:container:auth:username', 'testuser')
+        self.assertEqual(validate_config([]), "Registry auth configuration is incomplete")
+        PillarManager.set('ceph-salt:container:auth:password', 'testpassword')
+        self.assertEqual(validate_config([]), "Registry auth configuration is incomplete")
+        PillarManager.set('ceph-salt:container:auth:registry', '172.17.0.1:5000')
+        self.assertEqual(validate_config([]), None)
+
     def test_no_ceph_container_image_path(self):
         PillarManager.reset('ceph-salt:container:images:ceph')
         self.assertEqual(validate_config([]), "No Ceph container image path specified in config")


### PR DESCRIPTION
Instead of allowing the user to login to multiple registries (which in practice is not useful), we should only support login to a single registry.

This will allow us to better integrate with `cephadm` (https://github.com/ceph/ceph/pull/36012) in a follow-up PR.

Signed-off-by: Ricardo Marques <rimarques@suse.com>