### PR TITLE
Drop unqualified image name support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ In this case, it is up to the user to ensure that some form of time syncing is
 configured and running on all machines in the cluster before triggering
 `ceph-salt apply`. This is because `cephadm` will refuse to run without it.
 
-Finally we need to set the Ceph container image path:
+Finally we need to set the Ceph container image absolute path (relative path is
+not supported):
 
 ```
 /containers/images/ceph set docker.io/ceph/ceph:v15.2.2

--- a/ceph-salt-formula/salt/ceph-salt/files/registries.conf.j2
+++ b/ceph-salt-formula/salt/ceph-salt/files/registries.conf.j2
@@ -2,9 +2,6 @@
 # {% include "ceph-salt/files/managed-header.txt.j2" ignore missing %}
 # For more information on this configuration file, see containers-registries.conf(5)
 
-# An array of host[:port] registries to try when pulling an unqualified image, in order
-unqualified-search-registries = ["docker.io"]
-
 {% for reg in registries %}
 [[registry]]
 {% if reg.prefix is defined %}

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -93,6 +93,8 @@ def validate_config(host_ls):
     ceph_container_image_path = PillarManager.get('ceph-salt:container:images:ceph')
     if not ceph_container_image_path:
         return "No Ceph container image path specified in config"
+    if '.' not in ceph_container_image_path.split('/')[0]:
+        return "A relative image path was given, but only absolute image paths are supported"
     auth = PillarManager.get('ceph-salt:container:auth')
     if auth:
         username = auth.get('username')

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -138,6 +138,12 @@ PBVw2pLCZsH5ol3VJ1/DETsGRMzFubFeTUNOC3MzhhG+V"""
         PillarManager.reset('ceph-salt:container:images:ceph')
         self.assertEqual(validate_config([]), "No Ceph container image path specified in config")
 
+    def test_ceph_container_image_relative_path(self):
+        PillarManager.set('ceph-salt:container:images:ceph', 'ceph/ceph:v15.2.2')
+        self.assertEqual(validate_config([]),
+                         "A relative image path was given, but only absolute image paths "
+                         "are supported")
+
     def test_valid(self):
         self.assertEqual(validate_config([]), None)
 
@@ -210,6 +216,7 @@ SCzirUzUKN2oge2WieNI7MQ=
         PillarManager.set('ceph-salt:minions:admin', ['node1.ceph.com'])
         PillarManager.set('ceph-salt:updates:enabled', True)
         PillarManager.set('ceph-salt:updates:reboot', True)
+        PillarManager.set('ceph-salt:container:registries_enabled', True)
         PillarManager.set('ceph-salt:container:images:ceph', 'docker.io/ceph/daemon-base:latest')
         PillarManager.set('ceph-salt:ssh:user', 'root')
         PillarManager.set('ceph-salt:ssh:public_key', """ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ\


### PR DESCRIPTION
**This is an alternative to https://github.com/ceph/ceph-salt/pull/297.**

By removing the `unqualified-search-registries` setting, we force the user to always specify image full name.

**Fail:**
```
# podman pull ses/7/ceph/ceph:15.2.3.455.3.373
Error: error pulling image "ses/7/ceph/ceph:15.2.3.455.3.373": unable to pull ses/7/ceph/ceph:15.2.3.455.3.373: image name provided is a short name and no search registries are defined in the registries config file.
```

**Works:**
```
# podman pull registry.suse.com/ses/7/ceph/ceph:15.2.3.455.3.373
Trying to pull registry.suse.com/ses/7/ceph/ceph:15.2.3.455.3.373...
Getting image source signatures
Copying blob df41305a59b1 done  
Copying blob e258f0c054bc done  
Copying config 4ea80648d1 done  
Writing manifest to image destination
Storing signatures
4ea80648d17bea19f033934375b0668378c77c7e33a04eca9802d09aa3ce9707
```


Signed-off-by: Ricardo Marques <rimarques@suse.com>