### PR TITLE
Install rsync

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/software.sls
+++ b/ceph-salt-formula/salt/ceph-salt/software.sls
@@ -8,6 +8,7 @@ install required packages:
       - iputils
       - lsof
       - podman
+      - rsync
     - failhard: True
 
 /var/log/journal:


### PR DESCRIPTION
Since https://github.com/ceph/ceph-salt/pull/290 minions must have `rsync` installed in order to copy `ceph.conf`/`ceph.client.admin.keyring` files with correct permissions.

Signed-off-by: Ricardo Marques <rimarques@suse.com>