### PR TITLE
ceph-salt.spec: declare RPM dependencies

### DIFF
--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -52,6 +52,10 @@ Requires:       python3-ntplib >= 0.3.3
 %endif
 
 Requires:       ceph-salt-formula
+Requires:       iputils
+Requires:       lsof
+Requires:       podman
+Requires:       rsync
 Requires:       salt-master >= 3000
 Requires:       procps
 


### PR DESCRIPTION
ceph-salt installs a number of RPM packages on Salt minions. These are
listed in  ceph-salt-formula/salt/ceph-salt/software.sls

This commit declares these RPMs in ceph-salt.spec as run-time
dependencies of ceph-salt itself, even though ceph-salt only installs
and uses these packages on the minions. The rationale is:

1. When the minion RPM dependency list is buried in a Salt sls file,
   it can be difficult to figure out what the dependencies really are

2. The Salt Master node where ceph-salt is installed typically has the
   exact same repos as the minion nodes. By installing all the minion
   dependencies on the master node together with ceph-salt, we are
   "asserting" that the repos are OK and we can identify repo problems
   early on, before "ceph-salt apply" is run.

DeepSea adheres to the same practice (see its spec file).

Signed-off-by: Nathan Cutler <ncutler@suse.com>