### PR TITLE
Add 'ceph-salt update [--reboot] [minion_id]' command

### DIFF
--- a/ceph-salt-formula/salt/_states/ceph_orch.py
+++ b/ceph-salt-formula/salt/_states/ceph_orch.py
@@ -136,3 +136,39 @@ def copy_ceph_conf_and_keyring(name):
     if cmd_ret['retcode'] == 0:
         ret['result'] = True
     return ret
+
+
+def wait_for_ceph_orch_host_ok_to_stop(name, if_grain, timeout=36000):
+    """
+    Requires the following grains to be set:
+      - ceph-salt:execution:admin_host
+    """
+    ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
+    if_grain_value = __salt__['grains.get'](if_grain)
+    if if_grain_value:
+        host = __grains__['host']
+        __salt__['event.send']('ceph-salt/stage/begin',
+                               data={'desc': "Wait for 'ceph orch host ok-to-stop {}'".format(host)})
+        ok_to_stop = False
+        starttime = time.time()
+        timelimit = starttime + timeout
+        while not ok_to_stop:
+            is_timedout = time.time() > timelimit
+            if is_timedout:
+                ret['comment'] = 'Timeout value reached.'
+                return ret
+            admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
+            ssh_user = __pillar__['ceph-salt']['ssh']['user']
+            sudo = 'sudo ' if ssh_user != 'root' else ''
+            cmd_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
+                                              "-i /tmp/ceph-salt-ssh-id_rsa {}@{} "
+                                              "'{}ceph orch host ok-to-stop {}'".format(ssh_user, admin_host,
+                                                                                        sudo, host))
+            ok_to_stop = cmd_ret['retcode'] == 0
+            if not ok_to_stop:
+                logger.info("Waiting for 'ceph_orch.host_ok_to_stop'")
+                time.sleep(15)
+        __salt__['event.send']('ceph-salt/stage/end',
+                               data={'desc': "Wait for 'ceph orch host ok-to-stop {}'".format(host)})
+    ret['result'] = True
+    return ret

--- a/ceph-salt-formula/salt/ceph-salt/update/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/update/init.sls
@@ -1,0 +1,13 @@
+{% if 'ceph-salt' in grains and grains['ceph-salt']['member'] %}
+
+include:
+    - .update-begin
+    - .update
+    - .update-end
+
+{% else %}
+
+nothing to do in this node:
+  test.nop
+
+{% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/update/update-begin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/update/update-begin.sls
@@ -1,0 +1,32 @@
+reset updated:
+  grains.present:
+    - name: ceph-salt:execution:updated
+    - value: False
+
+reset failure:
+  grains.present:
+    - name: ceph-salt:execution:failed
+    - value: False
+
+{% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
+{% set ssh_user_group = 'root' if ssh_user == 'root' else 'users' %}
+
+# private key
+create ceph-salt-ssh-id_rsa:
+  file.managed:
+    - name: /tmp/ceph-salt-ssh-id_rsa
+    - user: {{ ssh_user }}
+    - group: {{ ssh_user_group }}
+    - mode: '0600'
+    - contents_pillar: ceph-salt:ssh:private_key
+    - failhard: True
+
+# public key
+create ceph-salt-ssh-id_rsa.pub:
+  file.managed:
+    - name: /tmp/ceph-salt-ssh-id_rsa.pub
+    - user: {{ ssh_user }}
+    - group: {{ ssh_user_group }}
+    - mode: '0644'
+    - contents_pillar: ceph-salt:ssh:public_key
+    - failhard: True

--- a/ceph-salt-formula/salt/ceph-salt/update/update-end.sls
+++ b/ceph-salt-formula/salt/ceph-salt/update/update-end.sls
@@ -1,0 +1,14 @@
+set updated:
+  grains.present:
+    - name: ceph-salt:execution:updated
+    - value: True
+
+remove ceph-salt-ssh-id_rsa:
+  file.absent:
+    - name: /tmp/ceph-salt-ssh-id_rsa
+    - failhard: True
+
+remove ceph-salt-ssh-id_rsa.pub:
+  file.absent:
+    - name: /tmp/ceph-salt-ssh-id_rsa.pub
+    - failhard: True

--- a/ceph-salt-formula/salt/ceph-salt/update/update.sls
+++ b/ceph-salt-formula/salt/ceph-salt/update/update.sls
@@ -1,0 +1,56 @@
+{% import 'macros.yml' as macros %}
+
+{{ macros.begin_stage('Update all packages') }}
+
+install required packages:
+  pkg.installed:
+    - pkgs:
+      - lsof
+    - failhard: True
+
+update packages:
+  module.run:
+    - name: pkg.upgrade
+    - failhard: True
+
+# in case any package update re-writes sudoers /etc/sudoers.d/<ssh_user>
+{{ macros.sudoers('configure sudoers after package update') }}
+
+{{ macros.end_stage('Update all packages') }}
+
+{% if pillar['ceph-salt']['updates']['reboot'] %}
+
+{{ macros.begin_stage('Find an admin host') }}
+wait for admin host:
+  ceph_orch.set_admin_host:
+    - failhard: True
+{{ macros.end_stage('Find an admin host') }}
+
+{{ macros.begin_stage('Check if reboot is needed') }}
+check if reboot is needed:
+  ceph_salt.set_reboot_needed:
+    - failhard: True
+{{ macros.end_stage('Check if reboot is needed') }}
+
+wait for ancestor minion:
+  ceph_salt.wait_for_ancestor_minion_grain:
+    - grain: ceph-salt:execution:updated
+    - if_grain: ceph-salt:execution:reboot_needed
+    - failhard: True
+
+wait for ceph orch ok-to-stop:
+  ceph_orch.wait_for_ceph_orch_host_ok_to_stop:
+    - if_grain: ceph-salt:execution:reboot_needed
+    - failhard: True
+
+reboot:
+   ceph_salt.reboot_if_needed:
+     - ignore_running_services: True
+     - failhard: True
+
+{% else %}
+
+skip reboot:
+  test.nop
+
+{% endif %}

--- a/ceph-salt-formula/salt/macros.yml
+++ b/ceph-salt-formula/salt/macros.yml
@@ -34,6 +34,7 @@
     - text:
       - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/ceph -s"
       - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/ceph orch host add *"
+      - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/ceph orch host ok-to-stop *"
       - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/ceph orch status --format=json"
       - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/python3"
       - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/rsync"

--- a/ceph_salt/__init__.py
+++ b/ceph_salt/__init__.py
@@ -139,5 +139,27 @@ def purge(non_interactive, yes_i_really_really_mean_it):
     sys.exit(retcode)
 
 
+@cli.command(name='update')
+@click.option('-n', '--non-interactive', is_flag=True, default=False,
+              help='Apply config in non-interactive mode')
+@click.option('-r', '--reboot', is_flag=True, default=False,
+              help='Reboot if needed')
+@click.argument('minion_id', required=False)
+def update(non_interactive, reboot, minion_id):
+    """
+    Update all packages
+    """
+    executor = CephSaltExecutor(not non_interactive, minion_id,
+                                'ceph-salt.update', {
+                                    'ceph-salt': {
+                                        'updates': {
+                                            'reboot': reboot
+                                        }
+                                    }
+                                })
+    retcode = executor.run()
+    sys.exit(retcode)
+
+
 if __name__ == '__main__':
     ceph_salt_main()

--- a/ceph_salt/execute.py
+++ b/ceph_salt/execute.py
@@ -1296,6 +1296,12 @@ class CephSaltExecutor:
                 logger.error("cannot find minion: %s", minion_id)
                 PP.pl_red("Cannot find minion '{}'".format(minion_id))
                 return 7
+        # ceph-salt.update called, but cluster not deployed yet
+        if state == 'ceph-salt.update' and not deployed:
+            logger.error("ceph cluster not deployed and ceph-salt.update called")
+            PP.pl_red("Ceph cluster is not deployed yet, please apply the config to "
+                      "bootstrap a new Ceph cluster first: \"ceph-salt apply\"")
+            return 8
         return 0
 
     @staticmethod


### PR DESCRIPTION
~~**After https://github.com/ceph/ceph-salt/pull/307**~~
~~**After https://github.com/ceph/ceph/pull/36232 is backported (https://github.com/ceph/ceph/pull/36450)**~~

---

This PR introduces the support for orchestrated updates and reboot, by providing a new `ceph-salt update [--reboot] [minion_id]` command to **update** all minions in **parallel**, and **reboot** them **sequentially** if needed.

By default `ceph-salt update` comand will update all hosts, in parallel, without rebooting them.
- If `--reboot` option is provided, ceph-salt will reboot minions sequentially (if needed).
- If `minion_id` is provided, update/reboot will only be applied on that minion.


![Screenshot from 2020-07-24 10-28-35](https://user-images.githubusercontent.com/14297426/88378258-8ea32100-cd98-11ea-9ea6-00eca4ce80c0.png)

(Note that this PR is moving a lot of files in order to make it possible to implement new commands)

Signed-off-by: Ricardo Marques <rimarques@suse.com>