### PR TITLE
Install 'ceph-base' on admin minions

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/cephtools.sls
@@ -11,6 +11,7 @@ install cephadm:
     - pkgs:
         - cephadm
 {% if 'admin' in grains['ceph-salt']['roles'] %}
+        - ceph-base
         - ceph-common
 {% endif %}
     - failhard: True


### PR DESCRIPTION
`ceph-salt` should install `ceph-base` on admin minions, so users will be able to use, for instance, `crushtool`.

Signed-off-by: Ricardo Marques <rimarques@suse.com>