### PR TITLE
Purge ceph clusters

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_orch.py
+++ b/ceph-salt-formula/salt/_modules/ceph_orch.py
@@ -15,3 +15,10 @@ def configured():
 def host_ls():
     ret = __salt__['cmd.run']("ceph orch host ls --format=json")
     return json.loads(ret)
+
+def fsid():
+    ret = __salt__['cmd.run_all']("ceph -s --format=json")
+    if ret['retcode'] == 0:
+        status = json.loads(ret['stdout'])
+        return status.get('fsid', None)
+    return None

--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 import json
 import socket
+import time
 
 def _send_event(tag, data):
     __salt__['event.send'](tag, data=data)
@@ -65,3 +66,10 @@ def probe_ntp(ahost):
         return 1
     except:
         return 3
+
+def is_safety_disengaged():
+    execution = __pillar__['ceph-salt'].get('execution', {})
+    safety_disengage_time = execution.get('safety_disengage_time')
+    if safety_disengage_time and safety_disengage_time + 60 > time.time():
+        return True
+    return False

--- a/ceph-salt-formula/salt/_states/ceph_salt.py
+++ b/ceph-salt-formula/salt/_states/ceph_salt.py
@@ -141,3 +141,12 @@ def wait_for_ancestor_minion_grain(name, grain, if_grain, timeout=36000):
             end_stage("Wait for '{}'".format(ancestor_minion))
     ret['result'] = True
     return ret
+
+def check_safety(name):
+    ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
+    cmd_ret = __salt__['ceph_salt.is_safety_disengaged']()
+    if cmd_ret is not True:
+        ret['comment'] = "Safety is not disengaged. Run 'ceph-salt disengage-safety' to disable protection against dangerous operations."
+        return ret
+    ret['result'] = True
+    return ret

--- a/ceph-salt-formula/salt/ceph-salt/purge/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/purge/init.sls
@@ -1,0 +1,16 @@
+{% if 'ceph-salt' in grains and grains['ceph-salt']['member'] %}
+
+check safety:
+   ceph_salt.check_safety:
+     - failhard: True
+
+remove clusters:
+   ceph_orch.rm_clusters:
+     - failhard: True
+
+{% else %}
+
+nothing to do in this node:
+  test.nop
+
+{% endif %}

--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -1,4 +1,5 @@
 # pylint: disable=arguments-differ
+from copy import deepcopy
 import itertools
 import logging
 import fnmatch
@@ -1299,7 +1300,8 @@ def run_config_cmdline(cmdline):
 
 
 def run_export(pretty):
-    config = PillarManager.get('ceph-salt')
+    config = deepcopy(PillarManager.get('ceph-salt'))
+    config.pop('execution', None)
     if pretty:
         PP.println(json.dumps(config, indent=4, sort_keys=True))
     else:


### PR DESCRIPTION
~~**After https://github.com/ceph/ceph-salt/pull/307**~~

---

This PR adds a `ceph-salt purge` that can be used to purge/destroy/remove all ceph clusters, useful for POCs:

![Screenshot from 2020-07-28 12-33-22](https://user-images.githubusercontent.com/14297426/88660419-959a9e00-d0ce-11ea-9cb5-bfe19bc92805.png)

Fixes: https://github.com/ceph/ceph-salt/issues/242