### PR TITLE
cephbootstrap: run bootstrap with --apply-spec

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -5,15 +5,16 @@
 {{ macros.begin_stage('Bootstrap the Ceph cluster') }}
 
 {% set bootstrap_ceph_conf = pillar['ceph-salt'].get('bootstrap_ceph_conf', {}) %}
+{% set bootstrap_ceph_conf_tmpfile = "/tmp/bootstrap-ceph.conf" %}
 
 create bootstrap ceph conf:
   cmd.run:
     - name: |
-        echo -en "" > /tmp/bootstrap-ceph.conf
+        echo -en "" > {{ bootstrap_ceph_conf_tmpfile }}
 {% for section, settings in bootstrap_ceph_conf.items() %}
-        echo -en "[{{ section }}]\n" >> /tmp/bootstrap-ceph.conf
+        echo -en "[{{ section }}]\n" >> {{ bootstrap_ceph_conf_tmpfile }}
 {% for setting, value in settings.items() %}
-        echo -en "        {{ setting }} = {{ value }}\n" >> /tmp/bootstrap-ceph.conf
+        echo -en "        {{ setting }} = {{ value }}\n" >> {{ bootstrap_ceph_conf_tmpfile }}
 {% endfor %}
 {% endfor %}
     - failhard: True
@@ -37,7 +38,7 @@ run cephadm bootstrap:
     - name: |
         CEPHADM_IMAGE={{ pillar['ceph-salt']['container']['images']['ceph'] }} \
         cephadm --verbose bootstrap \
-                --config /tmp/bootstrap-ceph.conf \
+                --config {{ bootstrap_ceph_conf_tmpfile }} \
 {%- if not pillar['ceph-salt']['dashboard']['password_update_required'] %}
                 --dashboard-password-noupdate \
 {%- endif %}

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -6,6 +6,23 @@
 
 {% set bootstrap_ceph_conf = pillar['ceph-salt'].get('bootstrap_ceph_conf', {}) %}
 {% set bootstrap_ceph_conf_tmpfile = "/tmp/bootstrap-ceph.conf" %}
+{% set bootstrap_spec_yaml_tmpfile = "/tmp/bootstrap-spec.yaml" %}
+
+create static bootstrap yaml:
+  cmd.run:
+    - name: |
+        echo -en "" > {{ bootstrap_spec_yaml_tmpfile }}
+        echo -en "service_type: mgr\n" >> {{ bootstrap_spec_yaml_tmpfile }}
+        echo -en "service_name: mgr\n" >> {{ bootstrap_spec_yaml_tmpfile }}
+        echo -en "placement:\n" >> {{ bootstrap_spec_yaml_tmpfile }}
+        echo -en "    hosts:\n" >> {{ bootstrap_spec_yaml_tmpfile }}
+        echo -en "        - {{ grains['host'] }}\n" >> {{ bootstrap_spec_yaml_tmpfile }}
+        echo -en "---\n" >> {{ bootstrap_spec_yaml_tmpfile }}
+        echo -en "service_type: mon\n" >> {{ bootstrap_spec_yaml_tmpfile }}
+        echo -en "service_name: mon\n" >> {{ bootstrap_spec_yaml_tmpfile }}
+        echo -en "placement:\n" >> {{ bootstrap_spec_yaml_tmpfile }}
+        echo -en "    hosts:\n" >> {{ bootstrap_spec_yaml_tmpfile }}
+        echo -en "        - {{ grains['host'] }}\n" >> {{ bootstrap_spec_yaml_tmpfile }}
 
 create bootstrap ceph conf:
   cmd.run:
@@ -38,6 +55,7 @@ run cephadm bootstrap:
     - name: |
         CEPHADM_IMAGE={{ pillar['ceph-salt']['container']['images']['ceph'] }} \
         cephadm --verbose bootstrap \
+                --apply-spec {{ bootstrap_spec_yaml_tmpfile }} \
                 --config {{ bootstrap_ceph_conf_tmpfile }} \
 {%- if not pillar['ceph-salt']['dashboard']['password_update_required'] %}
                 --dashboard-password-noupdate \

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -36,21 +36,22 @@ run cephadm bootstrap:
   cmd.run:
     - name: |
         CEPHADM_IMAGE={{ pillar['ceph-salt']['container']['images']['ceph'] }} \
-        cephadm --verbose bootstrap --mon-ip {{ pillar['ceph-salt']['bootstrap_mon_ip'] }} \
+        cephadm --verbose bootstrap \
                 --config /tmp/bootstrap-ceph.conf \
-                --initial-dashboard-user {{ dashboard_username }} \
-                --initial-dashboard-password {{ dashboard_password }} \
-                --ssh-user {{ ssh_user }} \
 {%- if not pillar['ceph-salt']['dashboard']['password_update_required'] %}
                 --dashboard-password-noupdate \
 {%- endif %}
-                --output-keyring /etc/ceph/ceph.client.admin.keyring \
+                --initial-dashboard-password {{ dashboard_password }} \
+                --initial-dashboard-user {{ dashboard_username }} \
+                --mon-ip {{ pillar['ceph-salt']['bootstrap_mon_ip'] }} \
                 --output-config /etc/ceph/ceph.conf \
+                --output-keyring /etc/ceph/ceph.client.admin.keyring \
                 --skip-monitoring-stack \
                 --skip-prepare-host \
                 --skip-pull \
                 --ssh-private-key /tmp/ceph-salt-ssh-id_rsa \
                 --ssh-public-key /tmp/ceph-salt-ssh-id_rsa.pub \
+                --ssh-user {{ ssh_user }} \
 {%- for arg, value in pillar['ceph-salt'].get('bootstrap_arguments', {}).items() %}
                 --{{ arg }} {{ value if value is not none else '' }} \
 {%- endfor %}


### PR DESCRIPTION
As reported in the downstream bug cited below, "cephadm bootstrap"
is now deploying 5 MONs and 2 MGRs by default.

The expectation is that "ceph-salt apply" will cause one (and only one)
MON and one (and only one) MGR to be deployed, and that both the MON and
the MGR will be deployed on the node specified by the user as the
bootstrap node.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1174422
Signed-off-by: Nathan Cutler <ncutler@suse.com>
