### PR TITLE
SSH pub and priv key should be set via 'cephadm'

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
@@ -15,8 +15,8 @@ copy ceph.conf and keyring from an admin node:
 configure cephadm mgr module:
   cmd.run:
     - name: |
-        ceph config-key set mgr/cephadm/ssh_identity_key -i /tmp/ceph-salt-ssh-id_rsa
-        ceph config-key set mgr/cephadm/ssh_identity_pub -i /tmp/ceph-salt-ssh-id_rsa.pub
+        ceph cephadm set-priv-key -i /tmp/ceph-salt-ssh-id_rsa
+        ceph cephadm set-pub-key -i /tmp/ceph-salt-ssh-id_rsa.pub
         ceph cephadm set-user {{ ssh_user }}
     - failhard: True
 


### PR DESCRIPTION
If we set config-keys directly, cephadm cache is not updated

Signed-off-by: Ricardo Marques <rimarques@suse.com>