### PR TITLE
Handle ValueError

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -1279,7 +1279,7 @@ def run_config_shell():
         try:
             shell.run_interactive()
             break
-        except (configshell.ExecutionError, CephSaltException) as ex:
+        except (configshell.ExecutionError, CephSaltException, ValueError) as ex:
             logger.exception(ex)
             PP.pl_red(ex)
     return True
@@ -1293,7 +1293,7 @@ def run_config_cmdline(cmdline):
     logger.info("running command: %s", cmdline)
     try:
         shell.run_cmdline(cmdline)
-    except (configshell.ExecutionError, CephSaltException) as ex:
+    except (configshell.ExecutionError, CephSaltException, ValueError) as ex:
         logger.exception(ex)
         PP.pl_red(ex)
     return True


### PR DESCRIPTION
This PR will gracefully handle ValueError.

**Before**
```
/time_server> set time_server disabled
Traceback (most recent call last):
  File "/usr/bin/ceph-salt", line 11, in <module>
    load_entry_point('ceph-salt==15.2.7+1595320580.g5f1ca53', 'console_scripts', 'ceph-salt')()
  File "/usr/lib/python3.6/site-packages/ceph_salt/__init__.py", line 23, in ceph_salt_main
    cli(prog_name='ceph-salt')
  File "/usr/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/ceph_salt/__init__.py", line 58, in config_shell
    if not run_config_shell():
  File "/usr/lib/python3.6/site-packages/ceph_salt/config_shell.py", line 1279, in run_config_shell
    shell.run_interactive()
  File "/usr/lib/python3.6/site-packages/configshell_fb/shell.py", line 900, in run_interactive
    self._cli_loop()
  File "/usr/lib/python3.6/site-packages/configshell_fb/shell.py", line 729, in _cli_loop
    self.run_cmdline(cmdline)
  File "/usr/lib/python3.6/site-packages/configshell_fb/shell.py", line 843, in run_cmdline
    self._execute_command(path, command, pparams, kparams)
  File "/usr/lib/python3.6/site-packages/configshell_fb/shell.py", line 818, in _execute_command
    result = target.execute_command(command, pparams, kparams)
  File "/usr/lib/python3.6/site-packages/configshell_fb/node.py", line 1406, in execute_command
    return method(*pparams, **kparams)
  File "/usr/lib/python3.6/site-packages/ceph_salt/config_shell.py", line 620, in ui_command_set
    self.get_child(option_name).ui_command_set(value)
  File "/usr/lib/python3.6/site-packages/configshell_fb/node.py", line 1796, in get_child
    % (self.path.rstrip('/'), name))
ValueError: No such path /time_server/time_server
```

**After**
```
/time_server> set time_server disabled
No such path /time_server/time_server
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>