### PR TITLE
aa-teardown can fail if apparmor is disabled on the boot command line

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/apparmor.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/apparmor.sls
@@ -12,6 +12,8 @@ aa-teardown:
   cmd.run:
     - onlyif:
       - sh -c "type aa-teardown"
+    - onfail:
+      - test: apparmor
     - failhard: True
 
 stop apparmor:


### PR DESCRIPTION
This is the same fix from https://github.com/SUSE/DeepSea/pull/1846

**How to reproduce:**
```
# cat /proc/cmdline
BOOT_IMAGE=/boot/vmlinuz-5.3.18-22-default root=UUID=2d848741-8315-401b-b235-77335f5a6a9d showopts apparmor=0 intel_idle.max_cstate=1 crashkernel=512M-:256M spectre_v2=off nospec nopti blk_mq=1 mitigations=off


/etc/default/grub:

GRUB_CMDLINE_LINUX_DEFAULT="showopts apparmor=0 intel_idle.max_cstate=1 crashkernel=512M-:256M spectre_v2=off nospec nopti blk_mq=1 mitigations=off"


grub2-mkconfig -o /boot/grub2/grub.cfg

reboot..
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>