### PR TITLE
Support SSH users that are configured by packages

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -3,6 +3,7 @@ import json
 import socket
 import time
 
+
 def _send_event(tag, data):
     __salt__['event.send'](tag, data=data)
     return {
@@ -12,17 +13,22 @@ def _send_event(tag, data):
         'comment': ''
     }
 
+
 def begin_stage(name):
     return _send_event('ceph-salt/stage/begin', data={'desc': name})
+
 
 def end_stage(name):
     return _send_event('ceph-salt/stage/end', data={'desc': name})
 
+
 def begin_step(name):
     return _send_event('ceph-salt/step/begin', data={'desc': name})
 
+
 def end_step(name):
     return _send_event('ceph-salt/step/end', data={'desc': name})
+
 
 def get_remote_grain(host, grain):
     """
@@ -45,13 +51,6 @@ def get_remote_grain(host, grain):
         return None
     return json.loads(ret['stdout'])['local']
 
-def set_remote_grain(host, grain, value):
-    ssh_user = __pillar__['ceph-salt']['ssh']['user']
-    sudo = 'sudo ' if ssh_user != 'root' else ''
-    return __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                   "-i /tmp/ceph-salt-ssh-id_rsa {}@{} "
-                                   "'{}salt-call grains.set {} {}'".format(ssh_user, host, sudo,
-                                                                           grain, value))
 
 def probe_ntp(ahost):
     import ntplib
@@ -66,6 +65,7 @@ def probe_ntp(ahost):
         return 1
     except:
         return 3
+
 
 def is_safety_disengaged():
     execution = __pillar__['ceph-salt'].get('execution', {})

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
@@ -16,7 +16,11 @@ install cephadm:
 {% endif %}
     - failhard: True
 
+# in case any package instalation re-writes sudoers /etc/sudoers.d/<ssh_user>
+{{ macros.sudoers('configure sudoers after package instalation') }}
+
 {% if grains['id'] == pillar['ceph-salt'].get('bootstrap_minion') %}
+
 /var/log/ceph:
   file.directory:
     - user: ceph

--- a/ceph-salt-formula/salt/ceph-salt/apply/software.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/software.sls
@@ -28,6 +28,9 @@ update packages:
     - name: pkg.upgrade
     - failhard: True
 
+# in case any package update re-writes sudoers /etc/sudoers.d/<ssh_user>
+{{ macros.sudoers('configure sudoers after package update') }}
+
 {{ macros.end_step('Update all packages') }}
 
 {% else %}

--- a/ceph-salt-formula/salt/ceph-salt/apply/sshkey.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/sshkey.sls
@@ -19,13 +19,9 @@ create ssh user:
       - {{ ssh_user_group }}
     - failhard: True
 
-configure sudoers:
-    file.append:
-        - name: /etc/sudoers.d/{{ssh_user}}
-        - text:
-          - "{{ssh_user}} ALL=(ALL) NOPASSWD: ALL"
-
 {% endif %}
+
+{{ macros.sudoers('configure sudoers') }}
 
 # make sure .ssh is present with the right permissions
 create ssh dir:

--- a/ceph-salt-formula/salt/macros.yml
+++ b/ceph-salt-formula/salt/macros.yml
@@ -24,3 +24,18 @@
 {% macro end_step(desc) -%}
 {{ send_event('end', 'step', desc) }}
 {%- endmacro %}
+
+{% macro sudoers(name) -%}
+{%- set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
+{% if ssh_user != 'root' %}
+{{name}}:
+  file.append:
+    - name: /etc/sudoers.d/{{ssh_user}}
+    - text:
+      - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/ceph -s"
+      - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/ceph orch host add *"
+      - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/ceph orch status --format=json"
+      - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/python3"
+      - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/rsync"
+{% endif %}
+{%- endmacro %}


### PR DESCRIPTION
If `ceph-salt config /ssh/user` is a user where `/etc/sudoers.d/<ssh_user>` will be configured by any package instalation [1], we need to overrride `/etc/sudoers.d/<ssh_user>` after package instalation/update.

This PR will also restrict sudoers permissions to what is needed (instead of simply configuring `"{{ssh_user}} ALL=(ALL) NOPASSWD: ALL"` which is very permissive)

[1] e.g., when `cephadm` package is installed, `cephadm` user is created and `/etc/sudoers.d/cephadm` if configured (may also happen with other packages)

Fixes: https://github.com/ceph/ceph-salt/issues/317

Signed-off-by: Ricardo Marques <rimarques@suse.com>