### PR TITLE
Change default SSH user from 'root' to 'ceph-salt'

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -538,7 +538,7 @@ add location=172.17.0.1:5000/docker.io prefix=docker.io insecure=true
             },
             'user': {
                 'help': 'SSH user',
-                'handler': PillarHandler('ceph-salt:ssh:user', 'root')
+                'handler': PillarHandler('ceph-salt:ssh:user', 'ceph-salt')
             },
         }
     },

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -223,7 +223,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertValueOption('/ssh/user',
                                'ceph-salt:ssh:user',
                                'myuser',
-                               'root')
+                               'ceph-salt')
 
     def test_time_server(self):
         self.assertFlagOption('/time_server',
@@ -286,7 +286,7 @@ class ConfigShellTest(SaltMockTestCase):
                 'cephadm': ['node1.ceph.com', 'node2.ceph.com']
             },
             'ssh': {
-                'user': 'root'
+                'user': 'ceph-salt'
             },
             'time_server': {
                 'enabled': True,


### PR DESCRIPTION
By default, create and use `ceph-salt` SSH user instead of using `root`.

Signed-off-by: Ricardo Marques <rimarques@suse.com>