### PR TITLE
Configure 'qualified-search-registries = ["docker.io"]'

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/files/registries.conf.j2
+++ b/ceph-salt-formula/salt/ceph-salt/apply/files/registries.conf.j2
@@ -2,6 +2,9 @@
 # {% include "ceph-salt/apply/files/managed-header.txt.j2" ignore missing %}
 # For more information on this configuration file, see containers-registries.conf(5)
 
+# An array of host[:port] registries to try when pulling an unqualified image, in order	
+unqualified-search-registries = ["docker.io"]
+
 {% for reg in registries %}
 [[registry]]
 {% if reg.prefix is defined %}


### PR DESCRIPTION
In https://github.com/ceph/ceph-salt/pull/299 we removed `qualified-search-registries = ["docker.io"]` from `registries.conf` but this is useful in case other containers are used later on.

However, we keep the restriction introduced in https://github.com/ceph/ceph-salt/pull/299 that forces the user to specify `ceph` image full name.

Fixes: https://github.com/ceph/ceph-salt/issues/309

Signed-off-by: Ricardo Marques <rimarques@suse.com>