### PR TITLE
'cephadm' MGR module should only be enabled after cluster bootstrapped

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/cephconfigure.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephconfigure.sls
@@ -23,6 +23,10 @@ copy ceph.conf and keyring from an admin node:
 
 {{ macros.end_stage('Ensure ceph.conf and keyring are present') }}
 
+{% set admin_minion = pillar['ceph-salt'].get('bootstrap_minion', pillar['ceph-salt']['minions']['admin'][0]) %}
+
+{% if grains['id'] == admin_minion %}
+
 {{ macros.begin_stage('Ensure cephadm MGR module is enabled') }}
 
 {% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
@@ -38,6 +42,8 @@ enable cephadm mgr module:
     - failhard: True
 
 {{ macros.end_stage('Ensure cephadm MGR module is enabled') }}
+
+{% endif %}
 
 {% endif %}
 


### PR DESCRIPTION
`cephadm` MGR module should be enabled by the bootstrap minion, or the first admin minion (if the bootstrap minion is not specified).

This will guarantee that `cephadm` MGR module will only be enabled after cluster is bootstrapped, to prevent the following error:

![Screenshot from 2020-08-10 10-16-02](https://user-images.githubusercontent.com/14297426/89772056-48202700-daf9-11ea-82ff-5e518f9348d5.png)


Signed-off-by: Ricardo Marques <rimarques@suse.com>