### PR TITLE
Add 'ceph-salt reboot [--force] [minion_id]' command

### DIFF
--- a/ceph-salt-formula/salt/_states/ceph_salt.py
+++ b/ceph-salt-formula/salt/_states/ceph_salt.py
@@ -33,13 +33,16 @@ def end_step(name):
     return _send_event('ceph-salt/step/end', data={'desc': name})
 
 
-def set_reboot_needed(name):
+def set_reboot_needed(name, force=False):
     ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
-    if __grains__.get('os_family') == 'Suse':
-        needs_reboot = __salt__['cmd.run_all']('zypper ps')['retcode'] > 0
+    if force:
+        needs_reboot = True
     else:
-        ret['comment'] = 'Unsupported distribution: Unable to check if reboot is needed'
-        return ret
+        if __grains__.get('os_family') == 'Suse':
+            needs_reboot = __salt__['cmd.run_all']('zypper ps')['retcode'] > 0
+        else:
+            ret['comment'] = 'Unsupported distribution: Unable to check if reboot is needed'
+            return ret
     __salt__['grains.set']('ceph-salt:execution:reboot_needed', needs_reboot)
     ret['result'] = True
     return ret

--- a/ceph-salt-formula/salt/ceph-salt/reboot/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/reboot/init.sls
@@ -1,0 +1,14 @@
+{% if 'ceph-salt' in grains and grains['ceph-salt']['member'] %}
+
+include:
+    - .reboot-begin
+    - ..common.sshkey
+    - .reboot
+    - .reboot-end
+
+{% else %}
+
+nothing to do in this node:
+  test.nop
+
+{% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/reboot/reboot-begin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/reboot/reboot-begin.sls
@@ -1,0 +1,9 @@
+reset rebooted:
+  grains.present:
+    - name: ceph-salt:execution:rebooted
+    - value: False
+
+reset failure:
+  grains.present:
+    - name: ceph-salt:execution:failed
+    - value: False

--- a/ceph-salt-formula/salt/ceph-salt/reboot/reboot-end.sls
+++ b/ceph-salt-formula/salt/ceph-salt/reboot/reboot-end.sls
@@ -1,0 +1,14 @@
+set rebooted:
+  grains.present:
+    - name: ceph-salt:execution:rebooted
+    - value: True
+
+remove ceph-salt-ssh-id_rsa:
+  file.absent:
+    - name: /tmp/ceph-salt-ssh-id_rsa
+    - failhard: True
+
+remove ceph-salt-ssh-id_rsa.pub:
+  file.absent:
+    - name: /tmp/ceph-salt-ssh-id_rsa.pub
+    - failhard: True

--- a/ceph-salt-formula/salt/ceph-salt/reboot/reboot.sls
+++ b/ceph-salt-formula/salt/ceph-salt/reboot/reboot.sls
@@ -37,5 +37,4 @@ wait for ceph orch ok-to-stop:
 
 reboot:
    ceph_salt.reboot_if_needed:
-     - ignore_running_services: True
      - failhard: True

--- a/ceph-salt-formula/salt/ceph-salt/reboot/reboot.sls
+++ b/ceph-salt-formula/salt/ceph-salt/reboot/reboot.sls
@@ -1,0 +1,41 @@
+{% import 'macros.yml' as macros %}
+
+install required packages:
+  pkg.installed:
+    - pkgs:
+      - lsof
+    - failhard: True
+
+{{ macros.begin_stage('Check if reboot is needed') }}
+check if reboot is needed:
+  ceph_salt.set_reboot_needed:
+    - force: {{ pillar['ceph-salt'].get('force-reboot', False) }}
+    - failhard: True
+{{ macros.end_stage('Check if reboot is needed') }}
+
+# if ceph cluster already exists, then minions are rebooted sequentially (orchestrated reboot)
+# otherwise minions are rebooted in parallel
+{% if pillar['ceph-salt'].get('execution', {}).get('deployed') != False %}
+
+wait for admin host:
+  ceph_orch.set_admin_host:
+    - if_grain: ceph-salt:execution:reboot_needed
+    - failhard: True
+
+wait for ancestor minion:
+  ceph_salt.wait_for_ancestor_minion_grain:
+    - grain: ceph-salt:execution:rebooted
+    - if_grain: ceph-salt:execution:reboot_needed
+    - failhard: True
+
+wait for ceph orch ok-to-stop:
+  ceph_orch.wait_for_ceph_orch_host_ok_to_stop:
+    - if_grain: ceph-salt:execution:reboot_needed
+    - failhard: True
+
+{% endif %}
+
+reboot:
+   ceph_salt.reboot_if_needed:
+     - ignore_running_services: True
+     - failhard: True

--- a/ceph-salt-formula/salt/ceph-salt/update/update.sls
+++ b/ceph-salt-formula/salt/ceph-salt/update/update.sls
@@ -50,7 +50,6 @@ wait for ceph orch ok-to-stop:
 
 reboot:
    ceph_salt.reboot_if_needed:
-     - ignore_running_services: True
      - failhard: True
 
 {% else %}

--- a/ceph_salt/__init__.py
+++ b/ceph_salt/__init__.py
@@ -161,5 +161,25 @@ def update(non_interactive, reboot, minion_id):
     sys.exit(retcode)
 
 
+@cli.command(name='reboot')
+@click.option('-n', '--non-interactive', is_flag=True, default=False,
+              help='Reboot in non-interactive mode')
+@click.option('-f', '--force', is_flag=True, default=False,
+              help='Force reboot even if not needed')
+@click.argument('minion_id', required=False)
+def reboot_cmd(non_interactive, force, minion_id):
+    """
+    Reboot hosts if needed
+    """
+    executor = CephSaltExecutor(not non_interactive, minion_id,
+                                'ceph-salt.reboot', {
+                                    'ceph-salt': {
+                                        'force-reboot': force
+                                    }
+                                })
+    retcode = executor.run()
+    sys.exit(retcode)
+
+
 if __name__ == '__main__':
     ceph_salt_main()

--- a/ceph_salt/execute.py
+++ b/ceph_salt/execute.py
@@ -646,6 +646,8 @@ class CephSaltController(EventListener):
         minion.rebooting = False
         if minion.stage_end('Reboot', event.stamp):
             self.renderer.minion_update(event.minion)
+        if 'ceph-salt' in self.model.pillar:
+            self.model.pillar['ceph-salt'].pop('force-reboot', None)
         executor = CephSaltExecutorThread(self, event.minion)
         executor.start()
 

--- a/ceph_salt/salt_event.py
+++ b/ceph_salt/salt_event.py
@@ -66,6 +66,12 @@ class EventListener:
             event (CephSaltEvent): the salt event
         """
 
+    def handle_warning_stage(self, event: CephSaltEvent):
+        """Handle warning stage ceph-salt event
+        Args:
+            event (CephSaltEvent): the salt event
+        """
+
     def handle_end_stage(self, event: CephSaltEvent):
         """Handle end stage ceph-salt event
         Args:
@@ -195,6 +201,8 @@ class SaltEventProcessor(threading.Thread):
                         listener.handle_end_step(wrapper)
                     elif event['tag'] == 'ceph-salt/minion_reboot':
                         listener.handle_minion_reboot(wrapper)
+                    elif event['tag'] == 'ceph-salt/stage/warning':
+                        listener.handle_warning_stage(wrapper)
                 elif event['tag'] == 'minion_start':
                     listener.handle_minion_start(wrapper)
                 elif fnmatch.fnmatch(event['tag'], 'salt/job/*/ret/*'):

--- a/ceph_salt/terminal_utils.py
+++ b/ceph_salt/terminal_utils.py
@@ -16,6 +16,7 @@ class PrettyPrinter:
         """
         RED = '\x1B[38;5;196m'
         GREEN = '\x1B[38;5;83m'
+        ORANGE = '\x1B[38;5;214m'
         ENDC = '\x1B[0m'
 
     @classmethod
@@ -45,6 +46,13 @@ class PrettyPrinter:
         """
         return PrettyPrinter._format(PrettyPrinter.Colors.RED, text)
 
+    @staticmethod
+    def orange(text):
+        """
+        Formats text as orange
+        """
+        return PrettyPrinter._format(PrettyPrinter.Colors.ORANGE, text)
+
     @classmethod
     def println(cls, text=None):
         """
@@ -70,6 +78,13 @@ class PrettyPrinter:
         Prints text formatted as red
         """
         cls.println(cls.red(text))
+
+    @classmethod
+    def pl_orange(cls, text):
+        """
+        Prints text formatted as orange
+        """
+        cls.println(cls.orange(text))
 
 
 def check_root_privileges(func):


### PR DESCRIPTION
~~After https://github.com/ceph/ceph-salt/pull/345~~

---

This PR adds `ceph-salt reboot [--force] [minion_id]` command.

- `ceph-salt reboot`: reboot nodes sequentially, if needed (`zypper ps`)
- `ceph-salt reboot --force`:  reboot nodes sequentially, regardless of `zypper ps`

Note that the `salt-master` must be rebooted manually, which should not be an issue because it's a good practice to not have `salt-master` as part of the ceph cluster.

Signed-off-by: Ricardo Marques <rimarques@suse.com>