### PR TITLE
execute: check for running jobs when failing to re-apply formula

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -222,8 +222,7 @@ min-similarity-lines=4
 
 
 [MISCELLANEOUS]
-notes=FIXME,
-      XXX,
+notes=XXX,
       TODO
 
 [IMPORTS]

--- a/ceph_salt/execute.py
+++ b/ceph_salt/execute.py
@@ -1249,6 +1249,8 @@ class CephSaltExecutor:
         result = SaltClient.local_cmd('ceph-salt:member', 'state.sls_exists', [state],
                                       tgt_type='grain')
         if not all(result.values()):
+            # FIXME: check whether we are running under SUMA. If so, then we
+            # cannot restart the salt-master
             PP.println("salt-master will be restarted to load {} formula".format(state))
             logger.info('restarting salt-master service')
             result = SaltClient.caller_cmd('service.restart', ['salt-master'])

--- a/ceph_salt/execute.py
+++ b/ceph_salt/execute.py
@@ -1261,9 +1261,16 @@ class CephSaltExecutor:
         result = SaltClient.local_cmd('ceph-salt:member', 'state.sls_exists', [state],
                                       tgt_type='grain')
         if not all(result.values()):
-            logger.error("%s formula still not found", state)
-            PP.pl_red("Could not find {} formula. Please check if ceph-salt-formula package "
-                      "is installed".format(state))
+            logger.error("%s formula still not found: checking for running Salt jobs", state)
+            result = SaltClient.local_cmd('ceph-salt:member', 'saltutil.running', tgt_type='grain')
+            if any(result.values()):
+                logger.error("Running Salt jobs detected: refusing to apply Salt Formula")
+                PP.pl_red("Running Salt jobs detected. The safest thing to do in this case is "
+                          "wait. Once the jobs complete or time out, you will be able to apply "
+                          "the Salt Formula again.")
+            else:
+                PP.pl_red("Could not find {} formula. Please check if ceph-salt-formula package "
+                          "is installed".format(state))
             return 4
 
         PP.println("Syncing minions with the master...")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -110,6 +110,10 @@ class SaltUtilMock:
     def sync_all(cls):
         return cls.sync_all_result
 
+    @classmethod
+    def running(cls):
+        return True
+
 
 class StateMock:
     @staticmethod


### PR DESCRIPTION
Originally, we thought that the only case when

    salt -G ceph-salt:member state.sls_exists ceph-salt

can fail is when the ceph-salt-formula package is not installed. Now we
know it can also fail when jobs initiated by an earlier invocation of
the Salt Formula are still running.

Check for such jobs and display a different error message in this case.

Fixes: https://github.com/ceph/ceph-salt/issues/327
Signed-off-by: Nathan Cutler <ncutler@suse.com>