### PR TITLE
ceph-salt-formula/sshkey.sls: more meaningful SSH key comment

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
+++ b/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
@@ -57,7 +57,7 @@ create ceph-salt-ssh-id_rsa.pub:
 install ssh key:
     ssh_auth.present:
       - user: {{ ssh_user }}
-      - comment: ssh_orchestrator_key
+      - comment: ssh_key_created_by_ceph_salt
       - config: /%h/.ssh/authorized_keys
       - name: {{ pillar['ceph-salt']['ssh']['public_key'] }}
       - failhard: True


### PR DESCRIPTION
This comment is displayed in the ".ssh/authorized_keys" file populated
by ceph-salt. Calling it "ssh_orchestrator_key" might confuse someone
reading that file into thinking that the key was created by the
Orchestrator.

Signed-off-by: Nathan Cutler <ncutler@suse.com>