### PR TITLE
tox,travis: test on Python 3.8 instead of 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ matrix:
   include:
   - python: 3.6
     env: TOX_ENV=py36
-  - python: 3.7
-    env: TOX_ENV=py37
-  - python: 3.7
+  - python: 3.8
+    env: TOX_ENV=py38
+  - python: 3.8
     env: TOX_ENV=lint
 install:
 - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,lint
+envlist = py36,lint
 minversion = 2.0
 skipsdist = True
 


### PR DESCRIPTION
And for local testing we can get away with 3.6 only. (It's convenient to
be able to run "tox" and not get all tests repeated in 3.8 after they
all ran once in 3.6.)

Fixes: https://github.com/ceph/ceph-salt/issues/336
Signed-off-by: Nathan Cutler <ncutler@suse.com>