### PR TITLE
setup.py: refrain from passing "setup_cfg=True" to distutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,4 +18,4 @@ def get_version_from_spec():
 
 setup(
     version=get_version_from_spec(),
-    setup_cfg=True)
+    )


### PR DESCRIPTION
distutil no longer recognizes this option.

Fixes: https://github.com/ceph/ceph-salt/issues/335
Signed-off-by: Nathan Cutler <ncutler@suse.com>