### PR TITLE
_send_event: write INFO message to minion log

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -1,10 +1,13 @@
 # -*- encoding: utf-8 -*-
 import json
+import logging
 import socket
 import time
 
+log = logging.getLogger(__name__)
 
 def _send_event(tag, data):
+    log.info("{}, data={}".format(tag, data))
     __salt__['event.send'](tag, data=data)
     return {
         'name': tag,


### PR DESCRIPTION
When states/steps begin or end, it will be useful to see that in the
minion log.

Fixes: https://github.com/ceph/ceph-salt/issues/342
Signed-off-by: Nathan Cutler <ncutler@suse.com>