### PR TITLE
Bootstrap minion don't need to wait for other minions

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -37,14 +37,6 @@ create bootstrap ceph conf:
 {% endfor %}
     - failhard: True
 
-{{ macros.begin_step('Wait for other minions') }}
-wait for other minions:
-  ceph_salt.wait_for_grain:
-    - grain: ceph-salt:execution:provisioned
-    - hosts: {{ pillar['ceph-salt']['minions']['all'] }}
-    - failhard: True
-{{ macros.end_step('Wait for other minions') }}
-
 {{ macros.begin_step('Run "cephadm bootstrap"') }}
 
 {% set dashboard_username = pillar['ceph-salt']['dashboard']['username'] %}


### PR DESCRIPTION
Since https://github.com/ceph/ceph-salt/pull/175/files#diff-1c9f70b41c7392e7d1254b03fbee4b3eL73-L75 the  bootstrap minion is no longer responsible for adding all hosts to `cephadm` (now, each node is responsible for adding itself), which means we no longer need to make `bootstrap minion` wait for all other minions.

Signed-off-by: Ricardo Marques <rimarques@suse.com>