### PR TITLE
[DNM] Pull container image in backgroud to prevent salt timeout

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
@@ -75,9 +75,7 @@ login into registry:
 
 {{ macros.begin_step('Download ceph container image') }}
 download ceph container image:
-  cmd.run:
-    - name: |
-        cephadm --image {{ pillar['ceph-salt']['container']['images']['ceph'] }} pull
+  ceph_orch.pull_image:
     - failhard: True
 {{ macros.end_step('Download ceph container image') }}
 


### PR DESCRIPTION
This PR will run `cephadm pull` in background to guarantee it will never reach salt timeout (5 min by default).


Signed-off-by: Ricardo Marques <rimarques@suse.com>