### PR TITLE
Only pull ceph image on bootstrap minion

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -2,6 +2,57 @@
 
 {% if grains['id'] == pillar['ceph-salt'].get('bootstrap_minion') %}
 
+{{ macros.begin_stage('Prepare to bootstrap the Ceph cluster') }}
+
+/var/log/ceph:
+  file.directory:
+    - user: ceph
+    - group: ceph
+    - mode: '0770'
+    - makedirs: True
+    - failhard: True
+
+{% set auth = pillar['ceph-salt'].get('container', {}).get('auth', {}) %}
+
+{% if auth %}
+
+{{ macros.begin_step('Login into registry') }}
+
+create ceph-salt-registry-json:
+  file.managed:
+    - name: /tmp/ceph-salt-registry-json
+    - source:
+        - salt://ceph-salt/files/registry-login-json.j2
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: '0600'
+    - backup: minion
+    - failhard: True
+
+login into registry:
+  cmd.run:
+    - name: |
+        cephadm registry-login \
+        --registry-url {{ auth.get('registry') }} \
+        --registry-username {{ auth.get('username') }} \
+        --registry-password {{ auth.get('password') }}
+    - failhard: True
+
+{{ macros.end_step('Login into registry') }}
+
+{% endif %}
+
+{{ macros.begin_step('Download ceph container image') }}
+download ceph container image:
+  cmd.run:
+    - name: |
+        cephadm --image {{ pillar['ceph-salt']['container']['images']['ceph'] }} pull
+    - failhard: True
+{{ macros.end_step('Download ceph container image') }}
+
+{{ macros.end_stage('Prepare to bootstrap the Ceph cluster') }}
+
 {{ macros.begin_stage('Bootstrap the Ceph cluster') }}
 
 {% set bootstrap_ceph_conf = pillar['ceph-salt'].get('bootstrap_ceph_conf', {}) %}

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
@@ -2,7 +2,7 @@
 
 {% if 'cephadm' in grains['ceph-salt']['roles'] %}
 
-{{ macros.begin_stage('Prepare to bootstrap the Ceph cluster') }}
+{{ macros.begin_stage('Configure cephadm') }}
 
 {{ macros.begin_step('Install cephadm and other packages') }}
 
@@ -19,17 +19,6 @@ install cephadm:
 # in case any package instalation re-writes sudoers /etc/sudoers.d/<ssh_user>
 {{ macros.sudoers('configure sudoers after package instalation') }}
 
-{% if grains['id'] == pillar['ceph-salt'].get('bootstrap_minion') %}
-
-/var/log/ceph:
-  file.directory:
-    - user: ceph
-    - group: ceph
-    - mode: '0770'
-    - makedirs: True
-    - failhard: True
-{% endif %}
-
 {{ macros.end_step('Install cephadm and other packages') }}
 
 {{ macros.begin_step('Run "cephadm check-host"') }}
@@ -42,45 +31,6 @@ have cephadm check the host:
 
 {{ macros.end_step('Run "cephadm check-host"') }}
 
-{% set auth = pillar['ceph-salt'].get('container', {}).get('auth', {}) %}
-
-{% if auth %}
-
-{{ macros.begin_step('Login into registry') }}
-
-create ceph-salt-registry-json:
-  file.managed:
-    - name: /tmp/ceph-salt-registry-json
-    - source:
-        - salt://ceph-salt/files/registry-login-json.j2
-    - template: jinja
-    - user: root
-    - group: root
-    - mode: '0600'
-    - backup: minion
-    - failhard: True
-
-login into registry:
-  cmd.run:
-    - name: |
-        cephadm registry-login \
-        --registry-url {{ auth.get('registry') }} \
-        --registry-username {{ auth.get('username') }} \
-        --registry-password {{ auth.get('password') }}
-    - failhard: True
-
-{{ macros.end_step('Login into registry') }}
-
-{% endif %}
-
-{{ macros.begin_step('Download ceph container image') }}
-download ceph container image:
-  cmd.run:
-    - name: |
-        cephadm --image {{ pillar['ceph-salt']['container']['images']['ceph'] }} pull
-    - failhard: True
-{{ macros.end_step('Download ceph container image') }}
-
-{{ macros.end_stage('Prepare to bootstrap the Ceph cluster') }}
+{{ macros.end_stage('Configure cephadm') }}
 
 {% endif %}


### PR DESCRIPTION
With this PR, ceph image will only be pulled on the bootstrap minion.

All other minions will pull ceph image via `cephadm` latter when needed.

The main motivation for this PR is to prevent `network overload` when pulling the image on all hosts in parallel (e.g. > 100 nodes)

Signed-off-by: Ricardo Marques <rimarques@suse.com>