### PR TITLE
Restrict to a maximum of 10 ceph image pull in parallel

### DIFF
--- a/ceph-salt-formula/salt/_states/ceph_salt.py
+++ b/ceph-salt-formula/salt/_states/ceph_salt.py
@@ -110,6 +110,35 @@ def wait_for_grain(name, grain, hosts, timeout=1800):
     return ret
 
 
+def wait_for_package(name, package, hosts, timeout=1800):
+    ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
+    completed_counter = 0
+    starttime = time.time()
+    timelimit = starttime + timeout
+    while completed_counter < len(hosts):
+        is_timedout = time.time() > timelimit
+        if is_timedout:
+            ret['comment'] = 'Timeout value reached.'
+            return ret
+        time.sleep(15)
+        completed_counter = 0
+        for host in hosts:
+            grain_value = __salt__['ceph_salt.get_remote_grain'](host, 'ceph-salt:execution:failed')
+            if grain_value:
+                ret['comment'] = 'One or more minions failed.'
+                return ret
+            ssh_user = __pillar__['ceph-salt']['ssh']['user']
+            cmd_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
+                                              "-i /tmp/ceph-salt-ssh-id_rsa {0}@{1} "
+                                              "'rpm -qa {2} | grep {2}'".format(ssh_user, host,
+                                                                                package))
+            if cmd_ret['retcode'] == 0:
+                completed_counter += 1
+        logger.info("Waiting for package '%s' (%s/%s)", package, completed_counter, len(hosts))
+    ret['result'] = True
+    return ret
+
+
 def wait_for_ancestor_minion_grain(name, grain, if_grain, timeout=36000):
     """
     This state will wait for a grain on the minion that appears immediately before
@@ -160,5 +189,131 @@ def check_safety(name):
     if cmd_ret is not True:
         ret['comment'] = "Safety is not disengaged. Run 'ceph-salt disengage-safety' to disable protection against dangerous operations."
         return ret
+    ret['result'] = True
+    return ret
+
+def _add_to_blocking_queue(host, max_queue_size, timeout):
+    python_script = '''
+import json
+import sys
+import time
+from filelock import FileLock, Timeout
+
+BLOCKING_QUEUE = '/tmp/ceph-salt-blocking-queue.json'
+BLOCKING_QUEUE_LOCK = '/tmp/ceph-salt-blocking-queue.lock'
+
+minion_id = '{0}'
+timeout = {1}
+max_queue_size = {2}
+starttime = time.time()
+timelimit = starttime + timeout
+while True:
+    is_timedout = time.time() > timelimit
+    if is_timedout:
+        print('Timeout value reached.', file=sys.stderr)
+        sys.exit(1)
+    lock = FileLock(BLOCKING_QUEUE_LOCK)
+    try:
+        with lock.acquire(timeout=0):
+            try:
+                with open(BLOCKING_QUEUE, 'r') as db_file:
+                    db_json = json.loads(db_file.read())
+            except (FileNotFoundError, json.decoder.JSONDecodeError):
+                db_json = []
+            if minion_id in db_json:
+                sys.exit(0)
+            elif len(db_json) < max_queue_size:
+                with open(BLOCKING_QUEUE, 'w') as db_file:
+                    db_json.append(minion_id)
+                    print(db_json)
+                    db_file.write(json.dumps(db_json))
+                    sys.exit(0)
+    except Timeout:
+        pass
+    time.sleep(5)
+'''.format(__grains__['id'], timeout, max_queue_size)
+    ssh_user = __pillar__['ceph-salt']['ssh']['user']
+    sudo = 'sudo ' if ssh_user != 'root' else ''
+    return __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
+                                   "-i /tmp/ceph-salt-ssh-id_rsa {}@{} "
+                                   "\"{}python3 - "
+                                   "<<EOF\n{}\nEOF\"".format(ssh_user,
+                                                             host,
+                                                             sudo,
+                                                             python_script))
+
+
+def _remove_from_blocking_queue(host, timeout):
+    python_script = '''
+import json
+import sys
+from filelock import FileLock
+
+BLOCKING_QUEUE = '/tmp/ceph-salt-blocking-queue.json'
+BLOCKING_QUEUE_LOCK = '/tmp/ceph-salt-blocking-queue.lock'
+
+minion_id = '{0}'
+timeout = {1}
+
+lock = FileLock(BLOCKING_QUEUE_LOCK)
+with lock.acquire(timeout=600):
+    try:
+        with open(BLOCKING_QUEUE, 'r') as db_file:
+            db_json = json.loads(db_file.read())
+    except (FileNotFoundError, json.decoder.JSONDecodeError):
+        db_json = []
+    with open(BLOCKING_QUEUE, 'w') as db_file:
+        if minion_id in db_json:
+            db_json.remove(minion_id)
+        print(db_json)
+        db_file.write(json.dumps(db_json))
+'''.format(__grains__['id'], timeout)
+    ssh_user = __pillar__['ceph-salt']['ssh']['user']
+    sudo = 'sudo ' if ssh_user != 'root' else ''
+    return __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
+                                   "-i /tmp/ceph-salt-ssh-id_rsa {}@{} "
+                                   "\"{}python3 - "
+                                   "<<EOF\n{}\nEOF\"".format(ssh_user,
+                                                             host,
+                                                             sudo,
+                                                             python_script))
+
+
+def pull_image(name, max_degree_of_parallelism=10, add_timeout=3600, remove_timeout=600):
+    ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
+    admin_minion = __pillar__['ceph-salt']['minions']['admin'][0]
+    required_package = 'python3-filelock'
+    __salt__['event.send']('ceph-salt/step/begin',
+                           data={'desc': "Wait for package '{}' to be available on '{}'".format(required_package, admin_minion)})
+    # Guarantee that 'admin_minion' has 'python3-filelock' installed
+    wait_ret = wait_for_package(name, required_package, [admin_minion])
+    if not wait_ret['result']:
+        return wait_ret
+    __salt__['event.send']('ceph-salt/step/end',
+                           data={'desc': "Wait for package '{}' to be available on '{}'".format(required_package, admin_minion)})
+    __salt__['event.send']('ceph-salt/step/begin',
+                           data={'desc': "Wait for other minions to complete download"})
+    # Wait for a slot to pull image
+    cmd_ret = _add_to_blocking_queue(admin_minion, max_degree_of_parallelism, add_timeout)
+    if cmd_ret['retcode'] > 0:
+        ret['comment'] = cmd_ret['stderr']
+        return ret
+    __salt__['event.send']('ceph-salt/step/end',
+                           data={'desc': "Wait for other minions to complete download"})
+    __salt__['event.send']('ceph-salt/step/begin',
+                           data={'desc': "Download ceph container image"})
+    # Pull image
+    ceph_image = __pillar__['ceph-salt']['container']['images']['ceph']
+    cmd_ret = __salt__['cmd.run_all']("cephadm --image {} pull".format(ceph_image))
+    if cmd_ret['retcode'] > 0:
+        ret['comment'] = 'Failed to pull image {}'.format(ceph_image)
+        return ret
+    # Release slot
+    cmd_ret = _remove_from_blocking_queue(admin_minion, remove_timeout)
+    if cmd_ret['retcode'] > 0:
+        ret['comment'] = cmd_ret['stderr']
+        return ret
+    __salt__['event.send']('ceph-salt/step/end',
+                           data={'desc': "Download ceph container image"})
     ret['result'] = True
     return ret

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
@@ -73,13 +73,9 @@ login into registry:
 
 {% endif %}
 
-{{ macros.begin_step('Download ceph container image') }}
 download ceph container image:
-  cmd.run:
-    - name: |
-        cephadm --image {{ pillar['ceph-salt']['container']['images']['ceph'] }} pull
+  ceph_salt.pull_image:
     - failhard: True
-{{ macros.end_step('Download ceph container image') }}
 
 {{ macros.end_stage('Prepare to bootstrap the Ceph cluster') }}
 

--- a/ceph-salt-formula/salt/ceph-salt/apply/software.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/software.sls
@@ -9,6 +9,7 @@ install required packages:
       - iputils
       - lsof
       - podman
+      - python3-filelock
       - rsync
     - failhard: True
 

--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -57,6 +57,7 @@ Requires:       iperf
 Requires:       iputils
 Requires:       lsof
 Requires:       podman
+Requires:       python3-filelock
 Requires:       rsync
 Requires:       salt-master >= 3000
 Requires:       procps


### PR DESCRIPTION
This PR will guarantee we will never have more than 10 minions pulling the ceph image at the same time, to **prevent network overload**.

To test on a small cluster, you can manually set the `max_degree_of_parallelism`:

```
download ceph container image:
  ceph_salt.pull_image:
    - max_degree_of_parallelism: 2
    - failhard: True
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>