### PR TITLE
Add tuned 'latency' and 'throughput' roles

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -365,6 +365,22 @@ CEPH_SALT_OPTIONS = {
                         'handler': RoleHandler('cephadm'),
                         'help': 'List of minions with Cephadm role'
                     },
+                    'tuned': {
+                        'type': 'group',
+                        'help': 'Tunes roles',
+                        'options': {
+                            'latency': {
+                                'type': 'minions',
+                                'handler': RoleHandler('latency'),
+                                'help': 'List of minions with Latency role'
+                            },
+                            'throughput': {
+                                'type': 'minions',
+                                'handler': RoleHandler('throughput'),
+                                'help': 'List of minions with Throughput role'
+                            },
+                        }
+                    },
                 }
             },
         }

--- a/ceph_salt/core.py
+++ b/ceph_salt/core.py
@@ -126,6 +126,12 @@ class CephNodeManager:
         PillarManager.set('ceph-salt:minions:cephadm',
                           [n.minion_id for n in cls._ceph_salt_nodes.values()
                            if 'cephadm' in n.roles])
+        PillarManager.set('ceph-salt:minions:latency',
+                          [n.minion_id for n in cls._ceph_salt_nodes.values()
+                           if 'latency' in n.roles])
+        PillarManager.set('ceph-salt:minions:throughput',
+                          [n.minion_id for n in cls._ceph_salt_nodes.values()
+                           if 'throughput' in n.roles])
 
     @classmethod
     def ceph_salt_nodes(cls):

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -44,6 +44,19 @@ def validate_config(deployed):
         if admin_minion not in cephadm_minions:
             return "Minion '{}' has 'admin' role but not 'cephadm' "\
                    "role".format(admin_minion)
+    latency_minions = PillarManager.get('ceph-salt:minions:latency', [])
+    throughput_minions = PillarManager.get('ceph-salt:minions:throughput', [])
+    for latency_minion in latency_minions:
+        if latency_minion not in cephadm_minions:
+            return "Minion '{}' has 'latency' role but not 'cephadm' "\
+                   "role".format(latency_minion)
+        if latency_minion in throughput_minions:
+            return "Minion '{}' has both 'latency' and 'throughput' "\
+                   "roles".format(latency_minion)
+    for throughput_minion in throughput_minions:
+        if throughput_minion not in cephadm_minions:
+            return "Minion '{}' has 'throughput' role but not 'cephadm' "\
+                   "role".format(throughput_minion)
 
     # ssh
     user = PillarManager.get('ceph-salt:ssh:user')

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -273,7 +273,9 @@ class ConfigShellTest(SaltMockTestCase):
             'minions': {
                 'all': ['node1.ceph.com', 'node2.ceph.com'],
                 'admin': ['node1.ceph.com'],
-                'cephadm': ['node1.ceph.com', 'node2.ceph.com']
+                'cephadm': ['node1.ceph.com', 'node2.ceph.com'],
+                'latency': [],
+                'throughput': []
             },
             'ssh': {
                 'user': 'ceph-salt'
@@ -296,7 +298,10 @@ class ConfigShellTest(SaltMockTestCase):
         self.fs.create_file('/config.json', contents=json.dumps({
             'minions': {
                 'all': ['node1.ceph.com', 'node2.ceph.com'],
-                'admin': ['node1.ceph.com']
+                'admin': ['node1.ceph.com'],
+                'cephadm': [],
+                'latency': [],
+                'throughput': []
             },
             'time_server': {
                 'server_host': 'node1.ceph.com',
@@ -315,6 +320,9 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:all'), ['node1.ceph.com',
                                                                       'node2.ceph.com'])
         self.assertEqual(PillarManager.get('ceph-salt:minions:admin'), ['node1.ceph.com'])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:latency'), [])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:cephadm'), [])
+        self.assertEqual(PillarManager.get('ceph-salt:minions:throughput'), [])
         self.assertIsNone(PillarManager.get('ceph-salt:bootstrap_minion'))
         self.assertEqual(PillarManager.get('ceph-salt:time_server:server_host'), 'node1.ceph.com')
         self.assertEqual(PillarManager.get('ceph-salt:time_server:subnet'), '10.20.188.0/24')

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -118,6 +118,31 @@ PBVw2pLCZsH5ol3VJ1/DETsGRMzFubFeTUNOC3MzhhG+V"""
         self.assertEqual(validate_config(False),
                          "Minion 'node3.ceph.com' has 'admin' role but not 'cephadm' role")
 
+    def test_latency_without_cephadm_role(self):
+        PillarManager.set('ceph-salt:bootstrap_minion', 'node2.ceph.com')
+        PillarManager.set('ceph-salt:minions:admin', ['node2.ceph.com'])
+        PillarManager.set('ceph-salt:minions:cephadm', ['node2.ceph.com'])
+        PillarManager.set('ceph-salt:minions:latency', ['node3.ceph.com'])
+        self.assertEqual(validate_config(False),
+                         "Minion 'node3.ceph.com' has 'latency' role but not 'cephadm' role")
+
+    def test_throughput_without_cephadm_role(self):
+        PillarManager.set('ceph-salt:bootstrap_minion', 'node2.ceph.com')
+        PillarManager.set('ceph-salt:minions:admin', ['node2.ceph.com'])
+        PillarManager.set('ceph-salt:minions:cephadm', ['node2.ceph.com'])
+        PillarManager.set('ceph-salt:minions:throughput', ['node3.ceph.com'])
+        self.assertEqual(validate_config(False),
+                         "Minion 'node3.ceph.com' has 'throughput' role but not 'cephadm' role")
+
+    def test_latency_and_throughput_roles(self):
+        PillarManager.set('ceph-salt:bootstrap_minion', 'node2.ceph.com')
+        PillarManager.set('ceph-salt:minions:admin', ['node2.ceph.com'])
+        PillarManager.set('ceph-salt:minions:cephadm', ['node2.ceph.com'])
+        PillarManager.set('ceph-salt:minions:latency', ['node2.ceph.com'])
+        PillarManager.set('ceph-salt:minions:throughput', ['node2.ceph.com'])
+        self.assertEqual(validate_config(False),
+                         "Minion 'node2.ceph.com' has both 'latency' and 'throughput' roles")
+
     def test_incomplete_registry_auth(self):
         PillarManager.set('ceph-salt:container:auth:username', 'testuser')
         self.assertEqual(validate_config(False), "Registry auth configuration is incomplete")


### PR DESCRIPTION
This PR is only the `UI`, `Pillar`, and `Grains` part that will be used by @swiftgist to implement corresponding salt state files:

![Screenshot from 2020-09-02 16-26-13](https://user-images.githubusercontent.com/14297426/92003538-12a5dc80-ed39-11ea-9d4b-c6052af0b4e1.png)


Signed-off-by: Ricardo Marques <rimarques@suse.com>