### PR TITLE
Always use cephadm SSH user (and more...)

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -34,21 +34,33 @@ def end_step(name):
     return _send_event('ceph-salt/step/end', data={'desc': name})
 
 
+def ssh(host, cmd):
+    return __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
+                                   "-i /home/cephadm/.ssh/id_rsa "
+                                   "cephadm@{} \"{}\"".format(host, cmd))
+
+def sudo_rsync(src, dest):
+    return __salt__['cmd.run_all']("sudo rsync --rsync-path='sudo rsync' "
+                                   "-e 'ssh -o StrictHostKeyChecking=no "
+                                   "-i /home/cephadm/.ssh/id_rsa' "
+                                   "{} {} ".format(src, dest))
+
 def get_remote_grain(host, grain):
     """
     Reads remote host grain by accessing '/etc/salt/grains' file directly.
     """
-    ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                  "-i /home/cephadm/.ssh/id_rsa cephadm@{} "
-                                  "\"sudo python3 - <<EOF\n"
-                                  "import json\n"
-                                  "import salt.utils.data\n"
-                                  "import yaml\n"
-                                  "with open('/etc/salt/grains') as grains_file:\n"
-                                  "    grains = yaml.full_load(grains_file)\n"
-                                  "val = salt.utils.data.traverse_dict_and_list(grains, '{}')\n"
-                                  "print(json.dumps({{'local': val}}))\n"
-                                  "EOF\"".format(host, grain))
+    python_script = '''
+import json
+import salt.utils.data
+import yaml
+with open('/etc/salt/grains') as grains_file:
+    grains = yaml.full_load(grains_file)
+val = salt.utils.data.traverse_dict_and_list(grains, '{}')
+print(json.dumps({{'local': val}}))
+'''.format(grain)
+    ret = __salt__['ceph_salt.ssh'](
+                   host,
+                   "sudo python3 - <<EOF\n{}\nEOF".format(python_script))
     if ret['retcode'] != 0:
         return None
     return json.loads(ret['stdout'])['local']

--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -36,12 +36,16 @@ def end_step(name):
 
 def ssh(host, cmd):
     return __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
+                                   "-o UserKnownHostsFile=/dev/null "
+                                   "-o ConnectTimeout=30 "
                                    "-i /home/cephadm/.ssh/id_rsa "
                                    "cephadm@{} \"{}\"".format(host, cmd))
 
 def sudo_rsync(src, dest):
     return __salt__['cmd.run_all']("sudo rsync --rsync-path='sudo rsync' "
                                    "-e 'ssh -o StrictHostKeyChecking=no "
+                                   "-o UserKnownHostsFile=/dev/null "
+                                   "-o ConnectTimeout=30 "
                                    "-i /home/cephadm/.ssh/id_rsa' "
                                    "{} {} ".format(src, dest))
 

--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -38,12 +38,9 @@ def get_remote_grain(host, grain):
     """
     Reads remote host grain by accessing '/etc/salt/grains' file directly.
     """
-    ssh_user = __pillar__['ceph-salt']['ssh']['user']
-    sudo = 'sudo ' if ssh_user != 'root' else ''
-    home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'    
     ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                  "-i {}/.ssh/id_rsa {}@{} "
-                                  "\"{}python3 - <<EOF\n"
+                                  "-i /home/cephadm/.ssh/id_rsa cephadm@{} "
+                                  "\"sudo python3 - <<EOF\n"
                                   "import json\n"
                                   "import salt.utils.data\n"
                                   "import yaml\n"
@@ -51,7 +48,7 @@ def get_remote_grain(host, grain):
                                   "    grains = yaml.full_load(grains_file)\n"
                                   "val = salt.utils.data.traverse_dict_and_list(grains, '{}')\n"
                                   "print(json.dumps({{'local': val}}))\n"
-                                  "EOF\"".format(home, ssh_user, host, sudo, grain))
+                                  "EOF\"".format(host, grain))
     if ret['retcode'] != 0:
         return None
     return json.loads(ret['stdout'])['local']

--- a/ceph-salt-formula/salt/_states/ceph_orch.py
+++ b/ceph-salt-formula/salt/_states/ceph_orch.py
@@ -33,19 +33,12 @@ def set_admin_host(name, if_grain=None, timeout=1800):
                 provisioned = __salt__['ceph_salt.get_remote_grain'](admin_host,
                                                                      'ceph-salt:execution:provisioned')
                 if provisioned:
-                    ssh_user = __pillar__['ceph-salt']['ssh']['user']
-                    sudo = 'sudo ' if ssh_user != 'root' else ''
-                    home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'                
                     status_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                                         "-i {}/.ssh/id_rsa {}@{} "
+                                                         "-i /home/cephadm/.ssh/id_rsa cephadm@{} "
                                                          "'if [[ -f /etc/ceph/ceph.conf "
                                                          "&& -f /etc/ceph/ceph.client.admin.keyring ]]; "
-                                                         "then timeout 60 {}ceph -s; "
-                                                         "else (exit 1); fi'".format(
-                                                             home,
-                                                             ssh_user,
-                                                             admin_host,
-                                                             sudo))
+                                                         "then timeout 60 sudo ceph -s; "
+                                                         "else (exit 1); fi'".format(admin_host))
                     if status_ret['retcode'] == 0:
                         configured_admin_host = admin_host
                         break
@@ -71,19 +64,12 @@ def wait_until_ceph_orch_available(name, timeout=1800):
             return ret
         time.sleep(15)
         admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
-        ssh_user = __pillar__['ceph-salt']['ssh']['user']
-        sudo = 'sudo ' if ssh_user != 'root' else ''
-        home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'    
         status_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                             "-i {}/.ssh/id_rsa {}@{} "
+                                             "-i /home/cephadm/.ssh/id_rsa cephadm@{} "
                                              "'if [[ -f /etc/ceph/ceph.conf "
                                              "&& -f /etc/ceph/ceph.client.admin.keyring ]]; "
-                                             "then timeout 60 {}ceph orch status --format=json; "
-                                             "else (exit 1); fi'".format(
-                                                 home,
-                                                 ssh_user,
-                                                 admin_host,
-                                                 sudo))
+                                             "then timeout 60 sudo ceph orch status --format=json; "
+                                             "else (exit 1); fi'".format(admin_host))
         if status_ret['retcode'] == 0:
             status = json.loads(status_ret['stdout'])
             if status.get('available'):
@@ -98,13 +84,9 @@ def add_host(name, host):
     """
     ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
     admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
-    ssh_user = __pillar__['ceph-salt']['ssh']['user']
-    sudo = 'sudo ' if ssh_user != 'root' else ''
-    home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'
     cmd_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                      "-i {}/.ssh/id_rsa {}@{} "
-                                      "'{}ceph orch host add {}'".format(home, ssh_user,
-                                                                         admin_host, sudo, host))
+                                      "-i /home/cephadm/.ssh/id_rsa cephadm@{} "
+                                      "'sudo ceph orch host add {}'".format(admin_host, host))
     if cmd_ret['retcode'] == 0:
         ret['result'] = True
     return ret
@@ -139,14 +121,11 @@ def copy_ceph_conf_and_keyring(name):
     """
     ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
     admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
-    ssh_user = __pillar__['ceph-salt']['ssh']['user']
-    sudo = 'sudo ' if ssh_user != 'root' else ''
-    home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'
-    cmd_ret = __salt__['cmd.run_all']("{1}rsync --rsync-path='{1}rsync' "
+    cmd_ret = __salt__['cmd.run_all']("sudo rsync --rsync-path='sudo rsync' "
                                       "-e 'ssh -o StrictHostKeyChecking=no "
-                                      "-i {0}/.ssh/id_rsa' "
-                                      "{2}@{3}:/etc/ceph/{{ceph.conf,ceph.client.admin.keyring}} "
-                                      "/etc/ceph/".format(home, sudo, ssh_user, admin_host))
+                                      "-i /home/cephadm/.ssh/id_rsa' "
+                                      "cephadm@{}:/etc/ceph/{{ceph.conf,ceph.client.admin.keyring}} "
+                                      "/etc/ceph/".format(admin_host))
     if cmd_ret['retcode'] == 0:
         ret['result'] = True
     return ret
@@ -172,15 +151,10 @@ def wait_for_ceph_orch_host_ok_to_stop(name, if_grain, timeout=36000):
                 ret['comment'] = 'Timeout value reached.'
                 return ret
             admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
-            ssh_user = __pillar__['ceph-salt']['ssh']['user']
-            sudo = 'sudo ' if ssh_user != 'root' else ''
-            home = '/home/{}'.format(ssh_user) if ssh_user != 'root' else '/root'    
             cmd_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                              "-i {}/.ssh/id_rsa {}@{} "
-                                              "'{}ceph orch host ok-to-stop {}'".format(home,
-                                                                                        ssh_user,
+                                              "-i /home/cephadm/.ssh/id_rsa cephadm@{} "
+                                              "'sudo ceph orch host ok-to-stop {}'".format(
                                                                                         admin_host,
-                                                                                        sudo,
                                                                                         host))
             ok_to_stop = cmd_ret['retcode'] == 0
             if not ok_to_stop:

--- a/ceph-salt-formula/salt/_states/ceph_orch.py
+++ b/ceph-salt-formula/salt/_states/ceph_orch.py
@@ -33,12 +33,12 @@ def set_admin_host(name, if_grain=None, timeout=1800):
                 provisioned = __salt__['ceph_salt.get_remote_grain'](admin_host,
                                                                      'ceph-salt:execution:provisioned')
                 if provisioned:
-                    status_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                                         "-i /home/cephadm/.ssh/id_rsa cephadm@{} "
-                                                         "'if [[ -f /etc/ceph/ceph.conf "
-                                                         "&& -f /etc/ceph/ceph.client.admin.keyring ]]; "
-                                                         "then timeout 60 sudo ceph -s; "
-                                                         "else (exit 1); fi'".format(admin_host))
+                    status_ret = __salt__['ceph_salt.ssh'](
+                        admin_host,
+                        "if [[ -f /etc/ceph/ceph.conf "
+                        "&& -f /etc/ceph/ceph.client.admin.keyring ]]; "
+                        "then timeout 60 sudo ceph -s; "
+                        "else (exit 1); fi")
                     if status_ret['retcode'] == 0:
                         configured_admin_host = admin_host
                         break
@@ -64,12 +64,12 @@ def wait_until_ceph_orch_available(name, timeout=1800):
             return ret
         time.sleep(15)
         admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
-        status_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                             "-i /home/cephadm/.ssh/id_rsa cephadm@{} "
-                                             "'if [[ -f /etc/ceph/ceph.conf "
-                                             "&& -f /etc/ceph/ceph.client.admin.keyring ]]; "
-                                             "then timeout 60 sudo ceph orch status --format=json; "
-                                             "else (exit 1); fi'".format(admin_host))
+        status_ret = __salt__['ceph_salt.ssh'](
+                        admin_host,
+                        "if [[ -f /etc/ceph/ceph.conf "
+                        "&& -f /etc/ceph/ceph.client.admin.keyring ]]; "
+                        "then timeout 60 sudo ceph orch status --format=json; "
+                        "else (exit 1); fi")
         if status_ret['retcode'] == 0:
             status = json.loads(status_ret['stdout'])
             if status.get('available'):
@@ -84,9 +84,9 @@ def add_host(name, host):
     """
     ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
     admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
-    cmd_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                      "-i /home/cephadm/.ssh/id_rsa cephadm@{} "
-                                      "'sudo ceph orch host add {}'".format(admin_host, host))
+    cmd_ret = __salt__['ceph_salt.ssh'](
+                       admin_host,
+                       "sudo ceph orch host add {}".format(host))
     if cmd_ret['retcode'] == 0:
         ret['result'] = True
     return ret
@@ -121,11 +121,9 @@ def copy_ceph_conf_and_keyring(name):
     """
     ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
     admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
-    cmd_ret = __salt__['cmd.run_all']("sudo rsync --rsync-path='sudo rsync' "
-                                      "-e 'ssh -o StrictHostKeyChecking=no "
-                                      "-i /home/cephadm/.ssh/id_rsa' "
-                                      "cephadm@{}:/etc/ceph/{{ceph.conf,ceph.client.admin.keyring}} "
-                                      "/etc/ceph/".format(admin_host))
+    cmd_ret = __salt__['ceph_salt.sudo_rsync'](
+                       "cephadm@{}:/etc/ceph/{{ceph.conf,ceph.client.admin.keyring}}".format(admin_host),
+                       "/etc/ceph/")
     if cmd_ret['retcode'] == 0:
         ret['result'] = True
     return ret
@@ -151,11 +149,9 @@ def wait_for_ceph_orch_host_ok_to_stop(name, if_grain, timeout=36000):
                 ret['comment'] = 'Timeout value reached.'
                 return ret
             admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
-            cmd_ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                              "-i /home/cephadm/.ssh/id_rsa cephadm@{} "
-                                              "'sudo ceph orch host ok-to-stop {}'".format(
-                                                                                        admin_host,
-                                                                                        host))
+            cmd_ret = __salt__['ceph_salt.ssh'](
+                               admin_host,
+                               "sudo ceph orch host ok-to-stop {}".format(host))
             ok_to_stop = cmd_ret['retcode'] == 0
             if not ok_to_stop:
                 logger.info("Waiting for 'ceph_orch.host_ok_to_stop'")

--- a/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
@@ -4,16 +4,14 @@
 
 {{ macros.begin_stage('Ensure cephadm MGR module is configured') }}
 
-{% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
-{% set home = '/home/' ~ssh_user if ssh_user != 'root' else '/root' %}
 {% set auth = pillar['ceph-salt'].get('container', {}).get('auth', {}) %}
 
 configure cephadm mgr module:
   cmd.run:
     - name: |
-        ceph cephadm set-priv-key -i {{ home }}/.ssh/id_rsa
-        ceph cephadm set-pub-key -i {{ home }}/.ssh/id_rsa.pub
-        ceph cephadm set-user {{ ssh_user }}
+        ceph cephadm set-priv-key -i /home/cephadm/.ssh/id_rsa
+        ceph cephadm set-pub-key -i /home/cephadm/.ssh/id_rsa.pub
+        ceph cephadm set-user cephadm
 {%- if auth %}
         ceph cephadm registry-login -i /tmp/ceph-salt-registry-json
 {%- endif %}

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -92,8 +92,6 @@ create bootstrap ceph conf:
 
 {% set dashboard_username = pillar['ceph-salt']['dashboard']['username'] %}
 {% set dashboard_password = pillar['ceph-salt']['dashboard']['password'] %}
-{% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
-{% set home = '/home/' ~ssh_user if ssh_user != 'root' else '/root' %}
 {% set auth = pillar['ceph-salt'].get('container', {}).get('auth', {}) %}
 
 {# --mon-ip is still required, even though we're also putting the Mon IP      #}
@@ -119,9 +117,9 @@ run cephadm bootstrap:
                 --skip-monitoring-stack \
                 --skip-prepare-host \
                 --skip-pull \
-                --ssh-private-key {{ home }}/.ssh/id_rsa \
-                --ssh-public-key {{ home }}/.ssh/id_rsa.pub \
-                --ssh-user {{ ssh_user }} \
+                --ssh-private-key /home/cephadm/.ssh/id_rsa \
+                --ssh-public-key /home/cephadm/.ssh/id_rsa.pub \
+                --ssh-user cephadm \
 {%- for arg, value in pillar['ceph-salt'].get('bootstrap_arguments', {}).items() %}
                 --{{ arg }} {{ value if value is not none else '' }} \
 {%- endfor %}

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephconfigure.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephconfigure.sls
@@ -25,15 +25,12 @@ copy ceph.conf and keyring from an admin node:
 
 {{ macros.begin_stage('Ensure cephadm MGR module is enabled') }}
 
-{% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
-{% set home = '/home/' ~ssh_user if ssh_user != 'root' else '/root' %}
-
 enable cephadm mgr module:
   cmd.run:
     - name: |
-        ceph config-key set mgr/cephadm/ssh_identity_key -i {{ home }}/.ssh/id_rsa
-        ceph config-key set mgr/cephadm/ssh_identity_pub -i {{ home }}/.ssh/id_rsa.pub
-        ceph config-key set mgr/cephadm/ssh_user {{ ssh_user }}
+        ceph config-key set mgr/cephadm/ssh_identity_key -i /home/cephadm/.ssh/id_rsa
+        ceph config-key set mgr/cephadm/ssh_identity_pub -i /home/cephadm/.ssh/id_rsa.pub
+        ceph config-key set mgr/cephadm/ssh_user cephadm
         ceph mgr module enable cephadm && \
         ceph orch set backend cephadm
     - failhard: True

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
@@ -16,9 +16,6 @@ install cephadm:
 {% endif %}
     - failhard: True
 
-# in case any package instalation re-writes sudoers /etc/sudoers.d/<ssh_user>
-{{ macros.sudoers('configure sudoers after package instalation') }}
-
 {{ macros.end_step('Install cephadm and other packages') }}
 
 {{ macros.begin_step('Run "cephadm check-host"') }}

--- a/ceph-salt-formula/salt/ceph-salt/apply/cleanup.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cleanup.sls
@@ -1,16 +1,5 @@
-{% if 'admin' not in grains['ceph-salt']['roles'] %}
-
-remove ceph-salt-ssh-id_rsa:
-  file.absent:
-    - name: /home/cephadm/.ssh/id_rsa
-    - failhard: True
-
-remove ceph-salt-ssh-id_rsa.pub:
-  file.absent:
-    - name: /home/cephadm/.ssh/id_rsa.pub
-    - failhard: True
-
-{% endif %}
+include:
+    - ..common.sshkey-cleanup
 
 remove ceph-salt-registry-json:
   file.absent:

--- a/ceph-salt-formula/salt/ceph-salt/apply/cleanup.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cleanup.sls
@@ -1,16 +1,13 @@
 {% if 'admin' not in grains['ceph-salt']['roles'] %}
 
-{% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
-{% set home = '/home/' ~ssh_user if ssh_user != 'root' else '/root' %}
-
 remove ceph-salt-ssh-id_rsa:
   file.absent:
-    - name: {{ home }}/.ssh/id_rsa
+    - name: /home/cephadm/.ssh/id_rsa
     - failhard: True
 
 remove ceph-salt-ssh-id_rsa.pub:
   file.absent:
-    - name: {{ home }}/.ssh/id_rsa.pub
+    - name: /home/cephadm/.ssh/id_rsa.pub
     - failhard: True
 
 {% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/common/sshkey-cleanup.sls
+++ b/ceph-salt-formula/salt/ceph-salt/common/sshkey-cleanup.sls
@@ -1,0 +1,13 @@
+{% if 'admin' not in grains['ceph-salt']['roles'] %}
+
+remove ceph-salt-ssh-id_rsa:
+  file.absent:
+    - name: /home/cephadm/.ssh/id_rsa
+    - failhard: True
+
+remove ceph-salt-ssh-id_rsa.pub:
+  file.absent:
+    - name: /home/cephadm/.ssh/id_rsa.pub
+    - failhard: True
+
+{% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
+++ b/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
@@ -14,7 +14,16 @@ create ssh user:
       - users
     - failhard: True
 
-{{ macros.sudoers('configure sudoers') }}
+configure sudoers:
+  file.append:
+    - name: /etc/sudoers.d/ceph-salt
+    - text:
+      - "cephadm ALL=NOPASSWD: /usr/bin/ceph -s"
+      - "cephadm ALL=NOPASSWD: /usr/bin/ceph orch host add *"
+      - "cephadm ALL=NOPASSWD: /usr/bin/ceph orch host ok-to-stop *"
+      - "cephadm ALL=NOPASSWD: /usr/bin/ceph orch status --format=json"
+      - "cephadm ALL=NOPASSWD: /usr/bin/python3"
+      - "cephadm ALL=NOPASSWD: /usr/bin/rsync"
 
 # make sure .ssh is present with the right permissions
 create ssh dir:

--- a/ceph-salt-formula/salt/ceph-salt/reboot/reboot-end.sls
+++ b/ceph-salt-formula/salt/ceph-salt/reboot/reboot-end.sls
@@ -1,18 +1,7 @@
+include:
+    - ..common.sshkey-cleanup
+
 set rebooted:
   grains.present:
     - name: ceph-salt:execution:rebooted
     - value: True
-
-{% if 'admin' not in grains['ceph-salt']['roles'] %}
-
-remove ceph-salt-ssh-id_rsa:
-  file.absent:
-    - name: /home/cephadm/.ssh/id_rsa
-    - failhard: True
-
-remove ceph-salt-ssh-id_rsa.pub:
-  file.absent:
-    - name: /home/cephadm/.ssh/id_rsa.pub
-    - failhard: True
-
-{% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/reboot/reboot-end.sls
+++ b/ceph-salt-formula/salt/ceph-salt/reboot/reboot-end.sls
@@ -5,17 +5,14 @@ set rebooted:
 
 {% if 'admin' not in grains['ceph-salt']['roles'] %}
 
-{% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
-{% set home = '/home/' ~ssh_user if ssh_user != 'root' else '/root' %}
-
 remove ceph-salt-ssh-id_rsa:
   file.absent:
-    - name: {{ home }}/.ssh/id_rsa
+    - name: /home/cephadm/.ssh/id_rsa
     - failhard: True
 
 remove ceph-salt-ssh-id_rsa.pub:
   file.absent:
-    - name: {{ home }}/.ssh/id_rsa.pub
+    - name: /home/cephadm/.ssh/id_rsa.pub
     - failhard: True
 
 {% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/update/update-end.sls
+++ b/ceph-salt-formula/salt/ceph-salt/update/update-end.sls
@@ -5,17 +5,14 @@ set updated:
 
 {% if 'admin' not in grains['ceph-salt']['roles'] %}
 
-{% set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
-{% set home = '/home/' ~ssh_user if ssh_user != 'root' else '/root' %}
-
 remove ceph-salt-ssh-id_rsa:
   file.absent:
-    - name: {{ home }}/.ssh/id_rsa
+    - name: /home/cephadm/.ssh/id_rsa
     - failhard: True
 
 remove ceph-salt-ssh-id_rsa.pub:
   file.absent:
-    - name: {{ home }}/.ssh/id_rsa.pub
+    - name: /home/cephadm/.ssh/id_rsa.pub
     - failhard: True
 
 {% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/update/update-end.sls
+++ b/ceph-salt-formula/salt/ceph-salt/update/update-end.sls
@@ -1,18 +1,7 @@
+include:
+    - ..common.sshkey-cleanup
+
 set updated:
   grains.present:
     - name: ceph-salt:execution:updated
     - value: True
-
-{% if 'admin' not in grains['ceph-salt']['roles'] %}
-
-remove ceph-salt-ssh-id_rsa:
-  file.absent:
-    - name: /home/cephadm/.ssh/id_rsa
-    - failhard: True
-
-remove ceph-salt-ssh-id_rsa.pub:
-  file.absent:
-    - name: /home/cephadm/.ssh/id_rsa.pub
-    - failhard: True
-
-{% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/update/update.sls
+++ b/ceph-salt-formula/salt/ceph-salt/update/update.sls
@@ -13,9 +13,6 @@ update packages:
     - name: pkg.upgrade
     - failhard: True
 
-# in case any package update re-writes sudoers /etc/sudoers.d/<ssh_user>
-{{ macros.sudoers('configure sudoers after package update') }}
-
 {{ macros.end_stage('Update all packages') }}
 
 {% if pillar['ceph-salt'].get('execution', {}).get('reboot-if-needed', False) %}

--- a/ceph-salt-formula/salt/macros.yml
+++ b/ceph-salt-formula/salt/macros.yml
@@ -24,16 +24,3 @@
 {% macro end_step(desc) -%}
 {{ send_event('end', 'step', desc) }}
 {%- endmacro %}
-
-{% macro sudoers(name) -%}
-{{name}}:
-  file.append:
-    - name: /etc/sudoers.d/cephadm
-    - text:
-      - "cephadm ALL=NOPASSWD: /usr/bin/ceph -s"
-      - "cephadm ALL=NOPASSWD: /usr/bin/ceph orch host add *"
-      - "cephadm ALL=NOPASSWD: /usr/bin/ceph orch host ok-to-stop *"
-      - "cephadm ALL=NOPASSWD: /usr/bin/ceph orch status --format=json"
-      - "cephadm ALL=NOPASSWD: /usr/bin/python3"
-      - "cephadm ALL=NOPASSWD: /usr/bin/rsync"
-{%- endmacro %}

--- a/ceph-salt-formula/salt/macros.yml
+++ b/ceph-salt-formula/salt/macros.yml
@@ -26,17 +26,14 @@
 {%- endmacro %}
 
 {% macro sudoers(name) -%}
-{%- set ssh_user = pillar['ceph-salt']['ssh']['user'] %}
-{% if ssh_user != 'root' %}
 {{name}}:
   file.append:
-    - name: /etc/sudoers.d/{{ssh_user}}
+    - name: /etc/sudoers.d/cephadm
     - text:
-      - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/ceph -s"
-      - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/ceph orch host add *"
-      - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/ceph orch host ok-to-stop *"
-      - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/ceph orch status --format=json"
-      - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/python3"
-      - "{{ssh_user}} ALL=NOPASSWD: /usr/bin/rsync"
-{% endif %}
+      - "cephadm ALL=NOPASSWD: /usr/bin/ceph -s"
+      - "cephadm ALL=NOPASSWD: /usr/bin/ceph orch host add *"
+      - "cephadm ALL=NOPASSWD: /usr/bin/ceph orch host ok-to-stop *"
+      - "cephadm ALL=NOPASSWD: /usr/bin/ceph orch status --format=json"
+      - "cephadm ALL=NOPASSWD: /usr/bin/python3"
+      - "cephadm ALL=NOPASSWD: /usr/bin/rsync"
 {%- endmacro %}

--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -517,10 +517,6 @@ add location=172.17.0.1:5000/docker.io prefix=docker.io insecure=false
                 'help': "SSH RSA public key",
                 'handler': SshPublicKeyHandler()
             },
-            'user': {
-                'help': 'SSH user',
-                'handler': PillarHandler('ceph-salt:ssh:user', 'ceph-salt')
-            },
         }
     },
     'time_server': {

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -46,9 +46,6 @@ def validate_config(deployed):
                    "role".format(admin_minion)
 
     # ssh
-    user = PillarManager.get('ceph-salt:ssh:user')
-    if not user:
-        return "No SSH user specified in config"
     priv_key = PillarManager.get('ceph-salt:ssh:private_key')
     if not priv_key:
         return "No SSH private key specified in config"

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -219,12 +219,6 @@ class ConfigShellTest(SaltMockTestCase):
                                 'ceph-salt:ssh:public_key',
                                 'mypublickey')
 
-    def test_ssh_user(self):
-        self.assertValueOption('/ssh/user',
-                               'ceph-salt:ssh:user',
-                               'myuser',
-                               'ceph-salt')
-
     def test_time_server(self):
         self.assertFlagOption('/time_server',
                               'ceph-salt:time_server:enabled',
@@ -274,9 +268,6 @@ class ConfigShellTest(SaltMockTestCase):
                 'all': ['node1.ceph.com', 'node2.ceph.com'],
                 'admin': ['node1.ceph.com'],
                 'cephadm': ['node1.ceph.com', 'node2.ceph.com']
-            },
-            'ssh': {
-                'user': 'ceph-salt'
             },
             'time_server': {
                 'enabled': True,

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -24,10 +24,6 @@ class ValidateConfigTest(SaltMockTestCase):
         self.assertEqual(validate_config(False), "Bootstrap minion must be 'Admin'")
         self.assertEqual(validate_config(True), None)
 
-    def test_ssh_no_user(self):
-        PillarManager.reset('ceph-salt:ssh:user')
-        self.assertEqual(validate_config(False), "No SSH user specified in config")
-
     def test_ssh_no_private_key(self):
         PillarManager.reset('ceph-salt:ssh:private_key')
         self.assertEqual(validate_config(False), "No SSH private key specified in config")
@@ -208,7 +204,6 @@ SCzirUzUKN2oge2WieNI7MQ=
         PillarManager.set('ceph-salt:minions:admin', ['node1.ceph.com'])
         PillarManager.set('ceph-salt:container:registries_enabled', True)
         PillarManager.set('ceph-salt:container:images:ceph', 'docker.io/ceph/daemon-base:latest')
-        PillarManager.set('ceph-salt:ssh:user', 'root')
         PillarManager.set('ceph-salt:ssh:public_key', """ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ\
 ClF4wYDBN6wC9Amp4xouZTDbOqZdkXxUezgbFrG1Nd+YtK7rF3sMdcE7ypKWkxwq3a/ZdWxnlAgQaCq2onXVo02/HhXrkaOf\
 fH2GKzhEIw6sW0FnZ+y6XpBh6nvlD87mD8mrQbnhsjFjX+odS8gmNJOZOBxHdeWy86PHUesjttAUYwi42fWB6LkJrz74nbkp\


### PR DESCRIPTION
This PR fixes the following issues:

- **Always use SSH 'cephadm' user** (https://github.com/ceph/ceph-salt/issues/357)
- **Add salt module for SSH executions** (https://github.com/ceph/ceph-salt/issues/360)
- **Set 'UserKnownHostsFile' and 'ConnectTimeout' on SSH connections** (https://github.com/ceph/ceph-salt/issues/362)
- **Rename '/etc/sudoers.d' file to avoid collision with cephadm**
- **Centralize SSH cleanup code**



Signed-off-by: Ricardo Marques <rimarques@suse.com>