### PR TITLE
Improve SSH keys stage description

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
+++ b/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
@@ -1,6 +1,6 @@
 {% import 'macros.yml' as macros %}
 
-{{ macros.begin_stage('Distribute SSH keys') }}
+{{ macros.begin_stage('Ensure SSH keys are configured') }}
 
 create ssh user group:
   group.present:
@@ -64,4 +64,4 @@ install ssh key:
       - name: {{ pillar['ceph-salt']['ssh']['public_key'] }}
       - failhard: True
 
-{{ macros.end_stage('Distribute SSH keys') }}
+{{ macros.end_stage('Ensure SSH keys are configured') }}


### PR DESCRIPTION
To make it clear that even if SSH keys are already distributed, we need to execute this stage to `Ensure SSH keys are configured`:

![Screenshot from 2020-09-08 16-26-54](https://user-images.githubusercontent.com/14297426/92497005-c226f700-f1f0-11ea-95ae-4df922243023.png)


Signed-off-by: Ricardo Marques <rimarques@suse.com>