### PR TITLE
Fix reboot in parallel with cluster running

### DIFF
--- a/ceph_salt/execute.py
+++ b/ceph_salt/execute.py
@@ -1347,6 +1347,10 @@ class CephSaltExecutor:
     @staticmethod
     def check_cluster(state, minion_id, deployed):
         PP.println("Checking if there is an existing Ceph cluster...")
+        if deployed:
+            PP.println("Ceph cluster already exists")
+        else:
+            PP.println("No Ceph cluster deployed yet")
 
         # day 1, but minion_id specified
         if state in ['ceph-salt', 'ceph-salt.apply']:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -162,8 +162,9 @@ class SaltLocalClientMock:
         self.logger = logging.getLogger(SaltLocalClientMock.__name__)
         self.grains = defaultdict(SaltGrainsMock)
 
-    def cmd(self, target, module, args=None, tgt_type=None):
-        self.logger.info('cmd %s, %s, %s, tgt_type=%s', target, module, args, tgt_type)
+    def cmd(self, target, module, args=None, tgt_type=None, full_return=False):
+        self.logger.info('cmd %s, %s, %s, tgt_type=%s, full_return=%s',
+                         target, module, args, tgt_type, full_return)
 
         if args is None:
             args = []


### PR DESCRIPTION
**Problem**
When executing `SaltClient.local_cmd('ceph-salt:roles:admin', 'ceph_orch.ceph_configured'`:
If minion `node1.pacific.test` is not responding,  it returns:
```
{'node1.pacific.test': False, ...}
```
which is exactly the same result when `node1.pacific.test` responds and ceph is not yet configured:
```
{'node1.pacific.test': False, ...}
```

**Fix**
We need to differentiate between `MINION IS NOT RESPONDING` and `MINION RESPONDED THAT CEPH IS NOT CONFIGURED`, to do that, we are now using `full_return=True` so:
If minion `node1.pacific.test` is not responding,  it returns:
```
{'node1.pacific.test': False, ...}
```
if minion responded, and ceph is not yet configured, it returns:
```
{'node1.pacific.test': {'ret': False, 'retcode': 0, 'jid': '20200908174918328862'}
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>