### PR TITLE
Support bootstrap minion without admin role

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -41,13 +41,14 @@ def ssh(host, cmd):
                                    "-i /home/cephadm/.ssh/id_rsa "
                                    "cephadm@{} \"{}\"".format(host, cmd))
 
-def sudo_rsync(src, dest):
+def sudo_rsync(src, dest, ignore_existing):
+    ignore_existing_option = '--ignore-existing ' if ignore_existing else ''
     return __salt__['cmd.run_all']("sudo rsync --rsync-path='sudo rsync' "
                                    "-e 'ssh -o StrictHostKeyChecking=no "
                                    "-o UserKnownHostsFile=/dev/null "
                                    "-o ConnectTimeout=30 "
                                    "-i /home/cephadm/.ssh/id_rsa' "
-                                   "{} {} ".format(src, dest))
+                                   "{}{} {} ".format(ignore_existing_option, src, dest))
 
 def get_remote_grain(host, grain):
     """

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -110,7 +110,7 @@ run cephadm bootstrap:
                 --initial-dashboard-password {{ dashboard_password }} \
                 --initial-dashboard-user {{ dashboard_username }} \
                 --output-config /etc/ceph/ceph.conf \
-                --output-keyring /etc/ceph/ceph.client.admin.keyring \
+                --output-keyring /tmp/ceph.client.admin.keyring \
 {%- if auth %}
                 --registry-json /tmp/ceph-salt-registry-json \
 {%- endif %}
@@ -128,10 +128,18 @@ run cephadm bootstrap:
       - NOTIFY_SOCKET: ''
     - creates:
       - /etc/ceph/ceph.conf
-      - /etc/ceph/ceph.client.admin.keyring
     - failhard: True
 
 {{ macros.end_step('Run "cephadm bootstrap"') }}
+
+copy ceph.conf and keyring to any admin node:
+  ceph_orch.copy_ceph_conf_and_keyring_to_any_admin:
+    - failhard: True
+
+remove temporary keyring:
+  file.absent:
+    - name: /tmp/ceph.client.admin.keyring
+    - failhard: True
 
 {{ macros.end_stage('Bootstrap the Ceph cluster') }}
 

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephconfigure.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephconfigure.sls
@@ -13,8 +13,8 @@ find an admin host:
 
 {{ macros.begin_stage('Ensure ceph.conf and keyring are present') }}
 
-copy ceph.conf and keyring from an admin node:
-  ceph_orch.copy_ceph_conf_and_keyring:
+copy ceph.conf and keyring from admin node:
+  ceph_orch.copy_ceph_conf_and_keyring_from_admin:
     - failhard: True
 
 {{ macros.end_stage('Ensure ceph.conf and keyring are present') }}

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
@@ -4,19 +4,17 @@
 
 {{ macros.begin_stage('Configure cephadm') }}
 
-{{ macros.begin_step('Install cephadm and other packages') }}
+{{ macros.begin_step('Install cephadm and other ceph packages') }}
 
 install cephadm:
   pkg.installed:
     - pkgs:
         - cephadm
-{% if 'admin' in grains['ceph-salt']['roles'] %}
         - ceph-base
         - ceph-common
-{% endif %}
     - failhard: True
 
-{{ macros.end_step('Install cephadm and other packages') }}
+{{ macros.end_step('Install cephadm and other ceph packages') }}
 
 {{ macros.begin_step('Run "cephadm check-host"') }}
 

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -8,12 +8,12 @@ def validate_config(deployed):
     """
     all_minions = PillarManager.get('ceph-salt:minions:all', [])
     bootstrap_minion = PillarManager.get('ceph-salt:bootstrap_minion')
-    admin_minions = PillarManager.get('ceph-salt:minions:admin', [])
+    cephadm_minions = PillarManager.get('ceph-salt:minions:cephadm', [])
     if not deployed:
         if not bootstrap_minion:
             return "No bootstrap minion specified in config"
-        if bootstrap_minion not in admin_minions:
-            return "Bootstrap minion must be 'Admin'"
+        if bootstrap_minion not in cephadm_minions:
+            return "Bootstrap minion must have 'cephadm' role"
         dashboard_username = PillarManager.get('ceph-salt:dashboard:username')
         if not dashboard_username:
             return "No dashboard username specified in config"
@@ -40,11 +40,13 @@ def validate_config(deployed):
             return "A relative image path was given, but only absolute image paths are supported"
 
     # roles
-    cephadm_minions = PillarManager.get('ceph-salt:minions:cephadm', [])
     for cephadm_minion in cephadm_minions:
         if cephadm_minion not in all_minions:
             return "Minion '{}' has 'cephadm' role but is not a cluster "\
                    "minion".format(cephadm_minion)
+    admin_minions = PillarManager.get('ceph-salt:minions:admin', [])
+    if not admin_minions:
+        return "No admin minion specified in config"
     for admin_minion in admin_minions:
         if admin_minion not in cephadm_minions:
             return "Minion '{}' has 'admin' role but not 'cephadm' "\


### PR DESCRIPTION
With this PR, the `bootstrap minion` will no longer be required to have the `admin` role.

The only role that is required for the `bootstrap minion` is the `cephadm` role because the `bootstrap minion` will belong to `ceph orch host ls`.

This PR will also add a check to guarantee that the configuration contains at least one admin minion.

Related PRs:
- https://github.com/SUSE/doc-ses/pull/529
- https://github.com/SUSE/sesdev/pull/461

Fixes: https://github.com/ceph/ceph-salt/issues/272

Signed-off-by: Ricardo Marques <rimarques@suse.com>