### PR TITLE
Install sudo package

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/software.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/software.sls
@@ -10,6 +10,7 @@ install required packages:
       - lsof
       - podman
       - rsync
+      - sudo
     - failhard: True
 
 /var/log/journal:

--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -59,6 +59,7 @@ Requires:       lsof
 Requires:       podman
 Requires:       rsync
 Requires:       salt-master >= 3000
+Requires:       sudo
 Requires:       procps
 
 Conflicts:      deepsea


### PR DESCRIPTION
We use `sudo`, so we need to make sure it is installed.

Signed-off-by: Ricardo Marques <rimarques@suse.com>