### PR TITLE
Ignore 'cephbootstrap' salt state when ceph cluster already running

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -1,6 +1,6 @@
 {% import 'macros.yml' as macros %}
 
-{% if grains['id'] == pillar['ceph-salt'].get('bootstrap_minion') %}
+{% if grains['id'] == pillar['ceph-salt'].get('bootstrap_minion') and pillar['ceph-salt'].get('execution', {}).get('deployed') != True %}
 
 {{ macros.begin_stage('Prepare to bootstrap the Ceph cluster') }}
 


### PR DESCRIPTION
It's confusing for the user to see the following messages when he knows that ceph cluster is already running:

![Screenshot from 2020-09-10 11-06-28](https://user-images.githubusercontent.com/14297426/92715672-b56fe380-f355-11ea-970e-1bbc030a0d0c.png)

So this PR will ignore `cephbootstrap.sls` when ceph cluster is already running.

Signed-off-by: Ricardo Marques <rimarques@suse.com>