### PR TITLE
Move ceph image path config to bootstrap section

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Finally we need to set the Ceph container image absolute path (relative path is
 not supported):
 
 ```
-/containers/images/ceph set docker.io/ceph/ceph:v15.2.2
+/cephadm_bootstrap/ceph_image_path set docker.io/ceph/ceph:v15.2.2
 ```
 
 Afterwards, you can exit the `ceph-salt` configuration shell by typing `exit`

--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -373,8 +373,7 @@ CEPH_SALT_OPTIONS = {
         'help': '''
                 Container Options Configuration
                 ====================================
-                Options to control the configuration of the Ceph containers used
-                for deployment.
+                Options to control the configuration of containers.
                 ''',
         'options': {
             'registry_auth': {
@@ -392,18 +391,6 @@ CEPH_SALT_OPTIONS = {
                     'registry': {
                         'help': 'URL of registry to login to',
                         'handler': PillarHandler('ceph-salt:container:auth:registry')
-                    },
-                }
-            },
-            'images': {
-                'type': 'group',
-                'help': "Container images paths",
-                'options': {
-                    'ceph': {
-                        'help': 'Full path of Ceph container image',
-                        'default_text': 'no image path',
-                        'required': True,
-                        'handler': PillarHandler('ceph-salt:container:images:ceph')
                     },
                 }
             },
@@ -463,6 +450,12 @@ add location=172.17.0.1:5000/docker.io prefix=docker.io insecure=false
                 'type': 'conf',
                 'help': 'Bootstrap Ceph configuration',
                 'handler': PillarHandler('ceph-salt:bootstrap_ceph_conf')
+            },
+            'ceph_image_path': {
+                'help': 'Full path of Ceph container image',
+                'default_text': 'no image path',
+                'required': True,
+                'handler': PillarHandler('ceph-salt:container:images:ceph')
             },
             'dashboard': {
                 'type': 'group',

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -33,6 +33,11 @@ def validate_config(deployed):
             return "No bootstrap Mon IP specified in config"
         if bootstrap_mon_ip in ['127.0.0.1', '::1']:
             return 'Mon IP cannot be the loopback interface IP'
+        ceph_container_image_path = PillarManager.get('ceph-salt:container:images:ceph')
+        if not ceph_container_image_path:
+            return "No Ceph container image path specified in config"
+        if '.' not in ceph_container_image_path.split('/')[0]:
+            return "A relative image path was given, but only absolute image paths are supported"
 
     # roles
     cephadm_minions = PillarManager.get('ceph-salt:minions:cephadm', [])
@@ -80,11 +85,6 @@ def validate_config(deployed):
             return not_minion_err.format('external time servers')
 
     # container
-    ceph_container_image_path = PillarManager.get('ceph-salt:container:images:ceph')
-    if not ceph_container_image_path:
-        return "No Ceph container image path specified in config"
-    if '.' not in ceph_container_image_path.split('/')[0]:
-        return "A relative image path was given, but only absolute image paths are supported"
     auth = PillarManager.get('ceph-salt:container:auth')
     if auth:
         username = auth.get('username')

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -110,11 +110,6 @@ class ConfigShellTest(SaltMockTestCase):
 
         self.shell.run_cmdline('/ceph_cluster/minions remove node1.ceph.com')
 
-    def test_containers_images_ceph(self):
-        self.assertValueOption('/containers/images/ceph',
-                               'ceph-salt:container:images:ceph',
-                               'myvalue')
-
     def test_containers_registries_conf(self):
         self.assertFlagOption('/containers/registries_conf',
                               'ceph-salt:container:registries_enabled',
@@ -174,6 +169,11 @@ class ConfigShellTest(SaltMockTestCase):
     def test_cephadm_bootstrap_ceph_conf(self):
         self.assertConfigOption('/cephadm_bootstrap/ceph_conf',
                                 'ceph-salt:bootstrap_ceph_conf')
+
+    def test_cephadm_bootstrap_ceph_image_path(self):
+        self.assertValueOption('/cephadm_bootstrap/ceph_image_path',
+                               'ceph-salt:container:images:ceph',
+                               'myvalue')
 
     def test_cephadm_bootstrap_dashboard_force_password_update(self):
         self.assertFlagOption('/cephadm_bootstrap/dashboard/force_password_update',


### PR DESCRIPTION
Ceph image path is only used for bootstrap, so this PR moves that config from `/containers/image/ceph` to the bootstrap section 
 (`/cephadm_bootstrap/ceph_image_path`) in order to make it clear that changing it after day 1 will not have any effect:


![Screenshot from 2020-09-10 18-41-40](https://user-images.githubusercontent.com/14297426/92774443-62b61c00-f395-11ea-893b-3b6760f42445.png)


Fixes: https://github.com/ceph/ceph-salt/issues/370

Signed-off-by: Ricardo Marques <rimarques@suse.com>
