### PR TITLE
Sync salt modules before using them on 'ceph-salt apply'

### DIFF
--- a/ceph_salt/validate/salt_minion.py
+++ b/ceph_salt/validate/salt_minion.py
@@ -1,0 +1,17 @@
+from ..exceptions import ValidationException
+from ..salt_utils import SaltClient
+
+
+class UnableToSyncAll(ValidationException):
+    def __init__(self):
+        super(UnableToSyncAll, self).__init__(
+            "Sync failed, please run: "
+            "\"salt -G 'ceph-salt:member' saltutil.sync_all\" manually and fix "
+            "the problems reported")
+
+
+def sync_all():
+    result = SaltClient.local_cmd('ceph-salt:member', 'saltutil.sync_all', tgt_type='grain')
+    for minion, value in result.items():
+        if not value:
+            raise UnableToSyncAll()

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -331,10 +331,10 @@ class ApplyTest(SaltMockTestCase):
     def test_check_formula_exists2(self):
         self.assertEqual(CephSaltExecutor.check_formula('ceph-salt'), 4)
 
-    def test_check_formula_exists3(self):
+    def test_check_sync_all(self):
         SaltUtilMock.sync_all_result = False
         self.fs.create_file(os.path.join(self.states_fs_path(), 'ceph-salt.sls'))
-        self.assertEqual(CephSaltExecutor.check_formula('ceph-salt'), 5)
+        self.assertEqual(CephSaltExecutor.check_sync_all(), 5)
         SaltUtilMock.sync_all_result = True
         self.fs.remove_object(os.path.join(self.states_fs_path(), 'ceph-salt.sls'))
 


### PR DESCRIPTION
`saltutil.sync_all` must be called before using the salt module that checks if ceph cluster is already deployed (`CephOrch.deployed()`).

Fixes: https://github.com/ceph/ceph-salt/issues/389

Signed-off-by: Ricardo Marques <rimarques@suse.com>