### PR TITLE
Change cephadm bootstrap output redirect file

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -123,7 +123,7 @@ run cephadm bootstrap:
 {%- for arg, value in pillar['ceph-salt'].get('bootstrap_arguments', {}).items() %}
                 --{{ arg }} {{ value if value is not none else '' }} \
 {%- endfor %}
-                > /var/log/ceph/cephadm.log 2>&1
+                > /var/log/ceph/cephadm.out 2>&1
     - env:
       - NOTIFY_SOCKET: ''
     - creates:


### PR DESCRIPTION
~~**After https://github.com/ceph/ceph/pull/36766**~~

---

Redirect `cephadm bootstrap` output to `/var/log/ceph/cephadm.out`, to avoid collision with cephadm.

Fixes: https://github.com/ceph/ceph-salt/issues/346

Signed-off-by: Ricardo Marques <rimarques@suse.com>