### PR TITLE
Use '--container-init' option on 'cephadm bootstrap'

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -106,6 +106,7 @@ run cephadm bootstrap:
                 --allow-fqdn-hostname \
                 --apply-spec {{ bootstrap_spec_yaml_tmpfile }} \
                 --config {{ bootstrap_ceph_conf_tmpfile }} \
+                --container-init \
 {%- if not pillar['ceph-salt']['dashboard']['password_update_required'] %}
                 --dashboard-password-noupdate \
 {%- endif %}

--- a/ceph-salt-formula/salt/ceph-salt/apply/software.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/software.sls
@@ -5,6 +5,7 @@
 install required packages:
   pkg.installed:
     - pkgs:
+      - catatonit
       - hostname
       - iperf
       - iputils

--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -52,6 +52,7 @@ Requires:       python3-ntplib >= 0.3.3
 Requires:       python3-netaddr
 %endif
 
+Requires:       catatonit
 Requires:       ceph-salt-formula
 Requires:       hostname
 Requires:       iperf


### PR DESCRIPTION
**After https://github.com/ceph/ceph/pull/36822 is backported**
**After https://tracker.ceph.com/issues/47501 is fixed**

---

**BEFORE**
![Screenshot from 2020-10-07 16-18-05](https://user-images.githubusercontent.com/14297426/95351084-b9d9de80-08b8-11eb-8e0e-363b275ae646.png)

**AFTER**
![Screenshot from 2020-10-07 16-17-51](https://user-images.githubusercontent.com/14297426/95351113-c100ec80-08b8-11eb-9062-825d83786859.png)


Fixes: https://github.com/ceph/ceph-salt/issues/347

Signed-off-by: Ricardo Marques <rimarques@suse.com>