### PR TITLE
Convert tags to repo_digest

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
@@ -16,6 +16,7 @@ configure cephadm mgr module:
         ceph cephadm registry-login -i /tmp/ceph-salt-registry-json
 {%- endif %}
         ceph config set mgr mgr/cephadm/manage_etc_ceph_ceph_conf true
+        ceph config set mgr mgr/cephadm/use_repo_digest true --force
     - failhard: True
 
 {{ macros.end_stage('Ensure cephadm MGR module is configured') }}


### PR DESCRIPTION
**After https://github.com/ceph/ceph/pull/36432 ~~is backported to octopus~~**

---

This PR will set:
```
# ceph config set mgr mgr/cephadm/use_repo_digest true --force
```
So tags will be converted to repo_digest:

![Screenshot from 2020-09-17 11-53-01](https://user-images.githubusercontent.com/14297426/93461335-8a007200-f8dc-11ea-8105-fc5d09594cfe.png)


Fixes: https://github.com/ceph/ceph-salt/issues/300

Signed-off-by: Ricardo Marques <rimarques@suse.com>