### PR TITLE
Retry SSH 'host add' execution on connection closed

### DIFF
--- a/ceph-salt-formula/salt/_states/ceph_orch.py
+++ b/ceph-salt-formula/salt/_states/ceph_orch.py
@@ -89,7 +89,8 @@ def add_host(name, host):
     admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
     cmd_ret = __salt__['ceph_salt.ssh'](
                        admin_host,
-                       "sudo ceph orch host add {}".format(host))
+                       "sudo ceph orch host add {}".format(host),
+                       attempts=10)
     if cmd_ret['retcode'] == 0:
         ret['result'] = True
     return ret


### PR DESCRIPTION
On large cluster deployments, sometimes we get the following error that is causing `ceph-salt apply` to fail:
```
2020-09-16 16:12:01,434 [salt.loaded.int.module.cmdmod:838 ][ERROR   ][9000] Command '['ssh', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'ConnectTimeout=30', '-i', '/home/cephadm/.ssh/id_rsa', 'cephadm@dpscalam17-monitor-1.openstack.local', 'sudo ceph orch host add dpscalam17-osd-44']' failed with return code: 255
2020-09-16 16:12:01,436 [salt.loaded.int.module.cmdmod:842 ][ERROR   ][9000] stderr: kex_exchange_identification: Connection closed by remote host
2020-09-16 16:12:01,436 [salt.loaded.int.module.cmdmod:844 ][ERROR   ][9000] retcode: 255
```

This error is caused by network flakiness, and since `ceph orch add <host>` is an idempotent operation, it's safe to retry it multiple times before failing.

Signed-off-by: Ricardo Marques <rimarques@suse.com>