### PR TITLE
Fix salt warn when 'ceph-salt config' is executed for the first time

### DIFF
--- a/ceph_salt/validate/salt_minion.py
+++ b/ceph_salt/validate/salt_minion.py
@@ -1,3 +1,5 @@
+import contextlib
+
 from ..exceptions import ValidationException
 from ..salt_utils import SaltClient
 
@@ -11,7 +13,8 @@ class UnableToSyncAll(ValidationException):
 
 
 def sync_all():
-    result = SaltClient.local_cmd('ceph-salt:member', 'saltutil.sync_all', tgt_type='grain')
+    with contextlib.redirect_stdout(None):
+        result = SaltClient.local_cmd('ceph-salt:member', 'saltutil.sync_all', tgt_type='grain')
     for minion, value in result.items():
         if not value:
             raise UnableToSyncAll()


### PR DESCRIPTION
With this PR, the following message will no longer be displayed on first `ceph-salt config` execution:

```
No minions matched the target. No command was sent, no jid was assigned.
```

The other warning message mentioned in the issue was already fixed on `configshell-fb`: https://github.com/open-iscsi/configshell-fb/pull/56 (we need to wait for a new `configshell-fb` package).

Fixes: https://github.com/ceph/ceph-salt/issues/393

Signed-off-by: Ricardo Marques <rimarques@suse.com>