### PR TITLE
Install 'sudo' before 'sudoers' configuration

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/software.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/software.sls
@@ -10,7 +10,6 @@ install required packages:
       - lsof
       - podman
       - rsync
-      - sudo
     - failhard: True
 
 /var/log/journal:

--- a/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
+++ b/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
@@ -14,6 +14,12 @@ create ssh user:
       - users
     - failhard: True
 
+install sudo:
+  pkg.installed:
+    - pkgs:
+      - sudo
+    - failhard: True
+
 configure sudoers:
   file.append:
     - name: /etc/sudoers.d/ceph-salt


### PR DESCRIPTION
The `sudo` package installation must happen before `sudoers` configuration, otherwise, we will get the following error on minions that don't have `sudo` installed.

```
/etc/sudoers.d/cephadm: file not found
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>