### PR TITLE
Validate '/cephadm_bootstrap/mon_ip'

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -1246,7 +1246,10 @@ def run_status():
     all = PillarManager.get('ceph-salt:minions:all', [])
     status['cluster'] = '{} minions, {} hosts managed by cephadm'.format(len(all), len(host_ls))
     deployed = CephOrch.deployed()
-    error_msg = validate_config(deployed)
+    nodes = {}
+    for minion in all:
+        nodes[minion] = CephNode(minion)
+    error_msg = validate_config(deployed, nodes)
     if error_msg:
         result = False
         logger.info(error_msg)

--- a/ceph_salt/core.py
+++ b/ceph_salt/core.py
@@ -7,7 +7,7 @@ from Cryptodome.PublicKey import RSA
 import salt
 
 from .exceptions import CephNodeHasRolesException
-from .salt_utils import SaltClient, GrainsManager, PillarManager
+from .salt_utils import GrainsManager, PillarManager, SaltClient
 
 
 logger = logging.getLogger(__name__)
@@ -19,12 +19,28 @@ CEPH_SALT_GRAIN_KEY = 'ceph-salt'
 class CephNode:
     def __init__(self, minion_id):
         self.minion_id = minion_id
+        self._ipsv4 = None
+        self._ipsv6 = None
         self._hostname = None
         self._roles = None
         self._execution = None
         self._public_ip = None
         self._subnets = None
         self._public_subnet = None
+
+    @property
+    def ipsv4(self):
+        if self._ipsv4 is None:
+            result = GrainsManager.get_grain(self.minion_id, 'ipv4')
+            self._ipsv4 = result[self.minion_id]
+        return self._ipsv4
+
+    @property
+    def ipsv6(self):
+        if self._ipsv6 is None:
+            result = GrainsManager.get_grain(self.minion_id, 'ipv6')
+            self._ipsv6 = result[self.minion_id]
+        return self._ipsv6
 
     @property
     def hostname(self):

--- a/ceph_salt/execute.py
+++ b/ceph_salt/execute.py
@@ -12,7 +12,7 @@ from typing import Dict, List
 
 import yaml
 
-from .core import CephNodeManager
+from .core import CephNode, CephNodeManager
 from .exceptions import MinionDoesNotExistInConfiguration, ValidationException
 from .logging_utils import LoggingUtil
 from .salt_event import EventListener, SaltEventProcessor
@@ -1536,7 +1536,11 @@ class CephSaltExecutor:
         deployed = CephOrch.deployed()
 
         # check config is valid
-        error_msg = validate_config(deployed)
+        all = PillarManager.get('ceph-salt:minions:all', [])
+        nodes = {}
+        for minion in all:
+            nodes[minion] = CephNode(minion)
+        error_msg = validate_config(deployed, nodes)
         if error_msg:
             logger.error(error_msg)
             PP.pl_red(error_msg)

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -2,7 +2,7 @@ from ..core import SshKeyManager
 from ..salt_utils import PillarManager
 
 
-def validate_config(deployed):
+def validate_config(deployed, ceph_nodes):
     """
     :return: Error message if config is invalid, otherwise "None"
     """
@@ -33,6 +33,13 @@ def validate_config(deployed):
             return "No bootstrap Mon IP specified in config"
         if bootstrap_mon_ip in ['127.0.0.1', '::1']:
             return 'Mon IP cannot be the loopback interface IP'
+        bootstrap_node = ceph_nodes.get(bootstrap_minion)
+        if bootstrap_node is None:
+            return "Cannot find minion '{}'".format(bootstrap_minion)
+        if bootstrap_mon_ip not in bootstrap_node.ipsv4 and \
+                bootstrap_mon_ip not in bootstrap_node.ipsv6:
+            return "Mon IP '{}' is not an IP of the bootstrap minion " \
+                   "'{}'".format(bootstrap_mon_ip, bootstrap_minion)
         ceph_container_image_path = PillarManager.get('ceph-salt:container:images:ceph')
         if not ceph_container_image_path:
             return "No Ceph container image path specified in config"


### PR DESCRIPTION
This PR will validate that `mon_ip` is an IP of the `bootstrap minion`:

```
master:~ # ceph-salt status
cluster: 4 minions, 0 hosts managed by cephadm
config:  Mon IP '192.168.20.300' is not an IP of the bootstrap minion 'node1.pacific.test'

master:~ # salt node1.pacific.test grains.get ipv4
node1.pacific.test:
    - 10.20.94.201
    - 127.0.0.1
    - 192.168.121.181

master:~ # ceph-salt config /cephadm_bootstrap/mon_ip set 10.20.94.201
Value set.

master:~ # ceph-salt status
cluster: 4 minions, 0 hosts managed by cephadm
config:  OK
```

Fixes: https://github.com/ceph/ceph-salt/issues/261

Signed-off-by: Ricardo Marques <rimarques@suse.com>