### PR TITLE
Add 'ceph-salt stop' command

### DIFF
--- a/ceph-salt-formula/salt/_states/ceph_salt.py
+++ b/ceph-salt-formula/salt/_states/ceph_salt.py
@@ -154,11 +154,26 @@ def wait_for_ancestor_minion_grain(name, grain, if_grain, timeout=36000):
     ret['result'] = True
     return ret
 
+
 def check_safety(name):
     ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
     cmd_ret = __salt__['ceph_salt.is_safety_disengaged']()
     if cmd_ret is not True:
         ret['comment'] = "Safety is not disengaged. Run 'ceph-salt disengage-safety' to disable protection against dangerous operations."
+        return ret
+    ret['result'] = True
+    return ret
+
+
+def check_fsid(name, formula):
+    ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
+    fsid = __salt__['pillar.get']('ceph-salt:execution:fsid')
+    if not fsid:
+        ret['comment'] = "No cluster FSID provided. Ceph cluster FSID " \
+                         "must be provided via custom Pillar value, e.g.: " \
+                         "\"salt -G ceph-salt:member state.apply {} " \
+                         "pillar='{{\"ceph-salt\": {{\"execution\": " \
+                         "{{\"fsid\": \"$FSID\"}}}}}}'\"".format(formula)
         return ret
     ret['result'] = True
     return ret

--- a/ceph-salt-formula/salt/ceph-salt/apply/apply-begin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/apply-begin.sls
@@ -1,4 +1,0 @@
-reset failure:
-  grains.present:
-    - name: ceph-salt:execution:failed
-    - value: False

--- a/ceph-salt-formula/salt/ceph-salt/apply/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/init.sls
@@ -1,7 +1,7 @@
 {% if 'ceph-salt' in grains and grains['ceph-salt']['member'] %}
 
 include:
-    - .apply-begin
+    - ..reset
     - ..common.sshkey
     - .tuned-off
     - .tuned-latency

--- a/ceph-salt-formula/salt/ceph-salt/purge/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/purge/init.sls
@@ -4,6 +4,11 @@ check safety:
    ceph_salt.check_safety:
      - failhard: True
 
+check fsid:
+   ceph_salt.check_fsid:
+     - formula: ceph-salt.purge
+     - failhard: True
+
 remove clusters:
    ceph_orch.rm_clusters:
      - failhard: True

--- a/ceph-salt-formula/salt/ceph-salt/reboot/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/reboot/init.sls
@@ -1,7 +1,7 @@
 {% if 'ceph-salt' in grains and grains['ceph-salt']['member'] %}
 
 include:
-    - .reboot-begin
+    - ..reset
     - ..common.sshkey
     - .reboot
     - .reboot-end

--- a/ceph-salt-formula/salt/ceph-salt/reboot/reboot-begin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/reboot/reboot-begin.sls
@@ -1,9 +1,0 @@
-reset rebooted:
-  grains.present:
-    - name: ceph-salt:execution:rebooted
-    - value: False
-
-reset failure:
-  grains.present:
-    - name: ceph-salt:execution:failed
-    - value: False

--- a/ceph-salt-formula/salt/ceph-salt/reset.sls
+++ b/ceph-salt-formula/salt/ceph-salt/reset.sls
@@ -1,0 +1,19 @@
+reset failure:
+  grains.present:
+    - name: ceph-salt:execution:failed
+    - value: False
+
+reset updated:
+  grains.present:
+    - name: ceph-salt:execution:updated
+    - value: False
+
+reset rebooted:
+  grains.present:
+    - name: ceph-salt:execution:rebooted
+    - value: False
+
+reset stopped:
+  grains.present:
+    - name: ceph-salt:execution:stopped
+    - value: False

--- a/ceph-salt-formula/salt/ceph-salt/stop/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/stop/init.sls
@@ -3,8 +3,8 @@
 include:
     - ..reset
     - ..common.sshkey
-    - .update
-    - .update-end
+    - .stop
+    - .stop-end
 
 {% else %}
 

--- a/ceph-salt-formula/salt/ceph-salt/stop/stop-end.sls
+++ b/ceph-salt-formula/salt/ceph-salt/stop/stop-end.sls
@@ -1,0 +1,7 @@
+include:
+    - ..common.sshkey-cleanup
+
+set stopped:
+  grains.present:
+    - name: ceph-salt:execution:stopped
+    - value: True

--- a/ceph-salt-formula/salt/ceph-salt/stop/stop.sls
+++ b/ceph-salt-formula/salt/ceph-salt/stop/stop.sls
@@ -1,0 +1,55 @@
+{% import 'macros.yml' as macros %}
+
+check fsid:
+   ceph_salt.check_fsid:
+     - formula: ceph-salt.stop
+     - failhard: True
+
+# first admin minion is the one who will stop services
+{% set admin_minion = pillar['ceph-salt']['minions']['admin'][0] %}
+
+{% if grains['id'] == admin_minion %}
+
+{{ macros.begin_stage('Ensure noout OSD flag is set') }}
+set noout osd flag:
+  ceph_orch.set_osd_flag:
+    - flag: noout
+    - failhard: True
+{{ macros.end_stage('Ensure noout OSD flag is set') }}
+
+{{ macros.begin_stage('Stop ceph services') }}
+
+{% for service in ['nfs', 'iscsi', 'rgw', 'mds', 'prometheus', 'grafana', 'node-exporter', 'alertmanager', 'rbd-mirror', 'crash', 'osd'] %}
+
+{{ macros.begin_step("Stop '" ~ service ~ "'") }}
+stop {{ service }}:
+  ceph_orch.stop_service:
+    - service: {{ service }}
+    - failhard: True
+
+wait {{ service }} stopped:
+  ceph_orch.wait_until_service_stopped:
+    - service: {{ service }}
+    - failhard: True
+{{ macros.end_step("Stop '" ~ service ~ "'") }}
+
+{% endfor %}
+
+{{ macros.end_stage('Stop ceph services') }}
+
+{% else %}
+
+{{ macros.begin_stage('Wait until ' ~ admin_minion ~ ' stops all ceph services') }}
+wait for admin stopped:
+  ceph_salt.wait_for_grain:
+    - grain: ceph-salt:execution:stopped
+    - hosts: [ {{ admin_minion }} ]
+    - failhard: True
+{{ macros.end_stage('Wait until ' ~ admin_minion ~ ' stops all ceph services') }}
+
+{% endif %}
+
+# Stop remaining services (mgr, mon)
+stop cluster:
+   ceph_orch.stop_ceph_fsid:
+     - failhard: True

--- a/ceph-salt-formula/salt/ceph-salt/update/update-begin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/update/update-begin.sls
@@ -1,9 +1,0 @@
-reset updated:
-  grains.present:
-    - name: ceph-salt:execution:updated
-    - value: False
-
-reset failure:
-  grains.present:
-    - name: ceph-salt:execution:failed
-    - value: False

--- a/ceph_salt/__init__.py
+++ b/ceph_salt/__init__.py
@@ -11,7 +11,7 @@ from .config_shell import run_config_cmdline, run_config_shell, run_status, run_
 from .exceptions import CephSaltException
 from .logging_utils import LoggingUtil
 from .terminal_utils import check_root_privileges, PrettyPrinter as PP
-from .execute import CephSaltExecutor, run_disengage_safety, run_purge
+from .execute import CephSaltExecutor, run_disengage_safety, run_purge, run_stop
 
 
 logger = logging.getLogger(__name__)
@@ -128,12 +128,12 @@ def disengage_safety():
 
 @cli.command(name='purge')
 @click.option('-n', '--non-interactive', is_flag=True, default=False,
-              help='Destroy all ceph clusters in non-interactive mode')
+              help='Destroy ceph cluster in non-interactive mode')
 @click.option('--yes-i-really-really-mean-it', is_flag=True, default=False,
               help='Confirm I really want to perform this dangerous operation')
 def purge(non_interactive, yes_i_really_really_mean_it):
     """
-    Destroy all ceph clusters
+    Destroy ceph cluster
     """
     retcode = run_purge(non_interactive, yes_i_really_really_mean_it, _prompt_proceed)
     sys.exit(retcode)
@@ -178,6 +178,19 @@ def reboot_cmd(non_interactive, force, minion_id):
                                     }
                                 }, _prompt_proceed)
     retcode = executor.run()
+    sys.exit(retcode)
+
+
+@cli.command(name='stop')
+@click.option('-n', '--non-interactive', is_flag=True, default=False,
+              help="Stop ceph cluster in non-interactive mode")
+@click.option('--yes-i-really-really-mean-it', is_flag=True, default=False,
+              help='Confirm I really want to perform this critical operation')
+def stop(non_interactive, yes_i_really_really_mean_it):
+    """
+    Stop ceph cluster
+    """
+    retcode = run_stop(non_interactive, yes_i_really_really_mean_it, _prompt_proceed)
     sys.exit(retcode)
 
 

--- a/ceph_salt/execute.py
+++ b/ceph_salt/execute.py
@@ -1581,7 +1581,6 @@ class CephSaltExecutor:
                 if retcode > 0:
                     return retcode, deployed
 
-        PP.println("Ready to start!")
         return 0, deployed
 
     def run(self):
@@ -1591,6 +1590,26 @@ class CephSaltExecutor:
                                                      self.prompt_proceed)
         if retcode > 0:
             return retcode
+
+        # Reset minions to make sure that all of them start the execution at the same state.
+        # For instance, ceph-salt relies on 'ceph-salt:execution:*' grains for the orchestration
+        # so we need to ensure that those grains are reset beforehand
+        PP.println("Reseting execution grains...")
+        if self.minion_id:
+            logger.info("Calling: salt '%s' state.apply ceph-salt.reset", self.minion_id)
+            returns = SaltClient.local().cmd(self.minion_id, 'state.apply',
+                                             ['ceph-salt.reset'])
+        else:
+            logger.info("Calling: salt -G 'ceph-salt:member' state.apply ceph-salt.reset")
+            returns = SaltClient.local().cmd('ceph-salt:member', 'state.apply',
+                                             ['ceph-salt.reset'],
+                                             tgt_type='grain')
+        for minion, data in returns.items():
+            for state, ret in data.items():
+                if not ret['result']:
+                    logger.error("%s - %s - %s", minion, state, ret)
+                    PP.pl_red('Failed to reset execution grains on {}'.format(minion))
+                    return 100
 
         # init
         self.model = CephSaltModel(self.minion_id, self.state, self.pillar)
@@ -1611,6 +1630,7 @@ class CephSaltExecutor:
         self.executor = CephSaltExecutorThread(self.controller, self.minion_id)
 
         # start
+        PP.println("Starting...")
         self.event_proc.start()
         self.executor.start()
         self.renderer.run()
@@ -1640,19 +1660,51 @@ def run_purge(non_interactive, yes_i_really_really_mean_it, prompt_proceed):
         if fsid is not None:
             break
     if not fsid:
-        PP.pl_red("Unable to find cluster FSID. Is ceph cluster deployed?")
+        PP.pl_red("Unable to find cluster FSID. Is ceph cluster running?")
         return 3
     if not yes_i_really_really_mean_it:
         if non_interactive:
-            PP.pl_red("This command would completely remove ceph cluster '{}' and all the data "
+            PP.pl_red("This command would completely REMOVE ceph cluster '{}' and all the data "
                       "it contains. If you are really sure you want to do that, include the "
                       "'--yes-i-really-really-mean-it' option.".format(fsid))
             return 4
-        prompt_proceed("You are about to permanently remove ceph cluster '{}'. "
+        prompt_proceed("You are about to permanently REMOVE ceph cluster '{}'. "
                        "Proceed?".format(fsid), 'n')
         prompt_proceed("Proceed, even though this may destroy valuable data?", 'n')
     executor = CephSaltExecutor(not non_interactive, None,
                                 'ceph-salt.purge', {
+                                    'ceph-salt': {
+                                        'execution': {
+                                            'fsid': fsid
+                                        }
+                                    }
+                                }, prompt_proceed)
+    return executor.run()
+
+
+def run_stop(non_interactive, yes_i_really_really_mean_it, prompt_proceed):
+    admin_minions = PillarManager.get('ceph-salt:minions:admin', [])
+    if not admin_minions:
+        PP.pl_red("No ceph-salt admin minions found.")
+        return 1
+    admin_minion = admin_minions[0]
+    fsid = SaltClient.local_cmd(admin_minion, 'ceph_orch.fsid',
+                                full_return=True)[admin_minion].get('ret')
+    if not fsid:
+        PP.pl_red("Unable to find cluster FSID. Is ceph cluster running?")
+        return 2
+    if not yes_i_really_really_mean_it:
+        if non_interactive:
+            PP.pl_red("This command will STOP ceph cluster '{}'. "
+                      "If you are really sure you want to do that, include the "
+                      "'--yes-i-really-really-mean-it' option.".format(fsid))
+            return 4
+        prompt_proceed("You are about to STOP ceph cluster '{}'. "
+                       "Proceed?".format(fsid), 'n')
+        prompt_proceed("Before proceeding, make sure any clients accessing the cluster are "
+                       "shut down or disconnected. Proceed?", 'n')
+    executor = CephSaltExecutor(not non_interactive, None,
+                                'ceph-salt.stop', {
                                     'ceph-salt': {
                                         'execution': {
                                             'fsid': fsid


### PR DESCRIPTION
The `ceph-salt stop` command will ~~check OSD `noout` flag, and~~ ask user confirmation:

![Screenshot from 2020-09-22 23-50-21](https://user-images.githubusercontent.com/14297426/93945231-6b600800-fd2e-11ea-8d3e-fc72b5bace47.png)


Then will stop ceph services:

![Screenshot from 2020-09-22 23-27-48](https://user-images.githubusercontent.com/14297426/93945005-00aecc80-fd2e-11ea-8720-05da070d5ed1.png)

At this point, if needed, it's now safe to manually shutdown hosts.



Fixes: https://github.com/ceph/ceph-salt/issues/359

Relates to: https://github.com/SUSE/doc-ses/issues/584

[1] https://susedoc.github.io/doc-ses/master/html/ses-admin/cha-ceph-operating.html#ceph-cluster-shutdown