### PR TITLE
Restart 'chronyd' service to apply chrony config

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/time-prep.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/time-prep.sls
@@ -33,13 +33,18 @@ service_reload:
 
 {{ macros.end_step('Configure chrony service') }}
 
-{{ macros.begin_step('Start chrony service') }}
+{{ macros.begin_step('Restart chrony service') }}
+stop chronyd:
+  service.dead:
+    - name: chronyd
+    - failhard: True
+
 start chronyd:
   service.running:
     - name: chronyd
     - enable: True
     - failhard: True
-{{ macros.end_step('Start chrony service') }}
+{{ macros.end_step('Restart chrony service') }}
 
 {{ macros.end_stage('Prepare cluster for time synchronization') }}
 


### PR DESCRIPTION
If 'chronyd' is already running before executing 'ceph-salt apply', then changes on '/etc/chrony.conf' are ignored, so chronyd must be restarted to ensure '/etc/chrony.conf' is loaded.

Signed-off-by: Ricardo Marques <rimarques@suse.com>