### PR TITLE
Display 'stderr' on stage/step failure

### DIFF
--- a/ceph-salt-formula/salt/_states/ceph_orch.py
+++ b/ceph-salt-formula/salt/_states/ceph_orch.py
@@ -93,6 +93,8 @@ def add_host(name, host):
                        attempts=10)
     if cmd_ret['retcode'] == 0:
         ret['result'] = True
+    else:
+        ret['comment'] = cmd_ret.get('stderr')
     return ret
 
 
@@ -115,6 +117,8 @@ def rm_clusters(name):
     if cmd_ret['retcode'] == 0:
         __salt__['ceph_salt.end_stage']("Remove cluster {}".format(fsid))
         ret['result'] = True
+    else:
+        ret['comment'] = cmd_ret.get('stderr')
     return ret
 
 
@@ -131,6 +135,8 @@ def copy_ceph_conf_and_keyring_from_admin(name):
                        False)
     if cmd_ret['retcode'] == 0:
         ret['result'] = True
+    else:
+        ret['comment'] = cmd_ret.get('stderr')
     return ret
 
 
@@ -141,14 +147,17 @@ def copy_ceph_conf_and_keyring_to_any_admin(name):
                        "/tmp/ceph.client.admin.keyring",
                        "cephadm@{}:/etc/ceph/ceph.client.admin.keyring".format(admin_host),
                        True)
-    if cmd_ret['retcode'] == 0:
-        ret['result'] = True
+    if cmd_ret['retcode'] != 0:
+        ret['comment'] = cmd_ret.get('stderr')
+        return ret
     cmd_ret = __salt__['ceph_salt.sudo_rsync'](
                        "/etc/ceph/ceph.conf",
                        "cephadm@{}:/etc/ceph/".format(admin_host),
                        True)
-    if cmd_ret['retcode'] == 0:
-        ret['result'] = True
+    if cmd_ret['retcode'] != 0:
+        ret['comment'] = cmd_ret.get('stderr')
+        return ret
+    ret['result'] = True
     return ret
 
 

--- a/ceph_salt/execute.py
+++ b/ceph_salt/execute.py
@@ -1056,7 +1056,7 @@ class CursesRenderer(Renderer, ScreenKeyListener):
             self.screen.write_body(row + line_num, col, "Error Description: ",
                                    CursesScreen.COLOR_MARKER)
             line_num += 1
-            for line in failure['changes']['stderr'].split('\n'):
+            for line in failure['changes'].get('stderr', '').split('\n'):
                 line_width = self.screen.body_width - col - 4
                 for sline in self.break_lines(line, line_width):
                     self.screen.write_body(row + line_num, col + 3, sline,
@@ -1067,7 +1067,7 @@ class CursesRenderer(Renderer, ScreenKeyListener):
                                    CursesScreen.COLOR_MARKER)
             line_num += 1
             line_width = self.screen.body_width - col - 4
-            for line in failure['comment'].split('\n'):
+            for line in failure.get('comment', '').split('\n'):
                 for sline in self.break_lines(line, line_width):
                     self.screen.write_body(row + line_num, col + 3, sline, CursesScreen.COLOR_ERROR)
                     line_num += 1


### PR DESCRIPTION
On some ceph-salt states, we are not displaying error description on failure:

**BEFORE**
![Screenshot from 2020-09-23 13-41-42](https://user-images.githubusercontent.com/14297426/94017918-e0235880-fda7-11ea-97e3-934de679c67b.png)

**AFTER**
![Screenshot from 2020-09-23 13-43-22](https://user-images.githubusercontent.com/14297426/94017906-de599500-fda7-11ea-8d75-f378dcbeb2cb.png)

Signed-off-by: Ricardo Marques <rimarques@suse.com>