### PR TITLE
Handle unresponsive minions properly

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -1310,8 +1310,6 @@ def run_import(config_file):
         if minion not in salt_minions:
             PP.pl_red("Cannot find minion '{}'".format(minion))
             return False
-    # Update pillar
-    PillarManager.set('ceph-salt', config)
     # Update grains
     minions = GrainsManager.filter_by('ceph-salt', 'member')
     if minions:
@@ -1323,5 +1321,7 @@ def run_import(config_file):
         if minion in minions_config.get('cephadm', []):
             node.add_role('cephadm')
         node.save()
+    # Update pillar
+    PillarManager.set('ceph-salt', config)
     PP.pl_green('Configuration imported.')
     return True

--- a/ceph_salt/execute.py
+++ b/ceph_salt/execute.py
@@ -1640,7 +1640,7 @@ def run_purge(non_interactive, yes_i_really_really_mean_it, prompt_proceed):
         return 2
     fsid = None
     for minion in admin_minions:
-        fsid = SaltClient.local().cmd(minion, 'ceph_orch.fsid')[minion]
+        fsid = SaltClient.local_cmd(minion, 'ceph_orch.fsid', full_return=True)[minion].get('ret')
         if fsid is not None:
             break
     if not fsid:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -182,21 +182,28 @@ class SaltLocalClientMock:
         for tgt in targets:
             mod, func = ModuleUtil.parse_module(module)
             if mod == 'grains':
-                result[tgt] = getattr(self.grains[tgt], func)(*args)
+                ret = getattr(self.grains[tgt], func)(*args)
             elif mod == 'test':
-                result[tgt] = getattr(TestMock, func)(*args)
+                ret = getattr(TestMock, func)(*args)
             elif mod == 'saltutil':
-                result[tgt] = getattr(SaltUtilMock, func)(*args)
+                ret = getattr(SaltUtilMock, func)(*args)
             elif mod == 'state':
-                result[tgt] = getattr(StateMock, func)(*args)
+                ret = getattr(StateMock, func)(*args)
             elif mod == 'service':
-                result[tgt] = getattr(ServiceMock, func)(*args)
+                ret = getattr(ServiceMock, func)(*args)
             elif mod == 'ceph_orch':
-                result[tgt] = getattr(CephOrchMock, func)(*args)
+                ret = getattr(CephOrchMock, func)(*args)
             elif mod == 'network':
-                result[tgt] = getattr(NetworkMock, func)(*args)
+                ret = getattr(NetworkMock, func)(*args)
             else:
                 raise NotImplementedError()
+            if full_return:
+                result[tgt] = {
+                    'ret': ret,
+                    'retcode': 0
+                }
+            else:
+                result[tgt] = ret
 
         self.logger.info("Grains: %s", self.grains)
 


### PR DESCRIPTION
MAIN PROBLEM
--

Execution of `SaltClient.local().cmd(...)` will return `False` value for minions that are down, so if `False` is a valid value in the context we are making that call, we will not distinguish between `False because the value is False` and `False because minion is down`.

SOLUTION
--
Use the `full_return` option, and if return is not a `dict`(e.g. `False`) means that execution failed (likely minion is down).

EXAMPLE
--

**1) Setting bootstrap minion, but bootstrap minion is down:**

**BEFORE**
![Screenshot from 2020-09-24 21-27-43](https://user-images.githubusercontent.com/14297426/94196831-d899a780-feac-11ea-8b0b-640655fac19a.png)

**AFTER**
![Screenshot from 2020-09-24 21-27-51](https://user-images.githubusercontent.com/14297426/94196843-dafc0180-feac-11ea-9213-502551b9e5c3.png)

The example above prints a traceback, just like in other actions like "Adding a minion that is down", but this is even more critical for scenarios like the next example.

**2) Get grain value, but minion is down:**

Imagine a scenario where we depend on `GrainsManager.get_grain('node1', 'ceph-salt:execution:failed')` but `node1` is down so it will return `False` and we will assume minion has not failed which is not true. This PR also fixes this situation.

Fixes: https://github.com/ceph/ceph-salt/issues/266

Signed-off-by: Ricardo Marques <rimarques@suse.com>