### PR TITLE
[WIP] Add FQDN support

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -102,6 +102,7 @@ run cephadm bootstrap:
         CEPHADM_IMAGE={{ pillar['ceph-salt']['container']['images']['ceph'] }} \
         cephadm --verbose bootstrap \
                 --mon-ip {{ pillar['ceph-salt']['bootstrap_mon_ip'] }} \
+                --allow-fqdn-hostname \
                 --apply-spec {{ bootstrap_spec_yaml_tmpfile }} \
                 --config {{ bootstrap_ceph_conf_tmpfile }} \
 {%- if not pillar['ceph-salt']['dashboard']['password_update_required'] %}


### PR DESCRIPTION
Ceph cluster must be bootstrapped with `--allow-fqdn-hostname`, otherwise FQDN hostnames will not work.

**TODO: Not tested yet. It should be possible to test a deployment that uses FQDNs, using sesdev?**

Fixes: https://github.com/ceph/ceph-salt/issues/417

Signed-off-by: Ricardo Marques <rimarques@suse.com>