### PR TITLE
ceph-salt.spec: add "Conflicts: deepsea-cli"

### DIFF
--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -63,6 +63,7 @@ Requires:       sudo
 Requires:       procps
 
 Conflicts:      deepsea
+Conflicts:      deepsea-cli
 
 %description
 ceph-salt is a CLI tool for deploying Ceph clusters starting from version


### PR DESCRIPTION
Having "Conflicts: deepsea" by itself is probably sufficient to make it
impossible for deepsea-cli and ceph-salt to coexist, but we might as
well declare the conflict explicitly to eliminate doubt.

References: https://bugzilla.suse.com/show_bug.cgi?id=1174532
Signed-off-by: Nathan Cutler <ncutler@suse.com>