### PR TITLE
Do the right thing in FQDN environments

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -176,3 +176,20 @@ def __check_unit(unit_name):
     elif out in ['failed', 'auto-restart']:
         state = 'error'
     return (enabled, installed, state)
+
+
+def hostname():
+    return socket.gethostname()
+
+
+def probe_fqdn():
+    """
+    Returns 'YES' if FQDN environment detected, 'NO' if not detected, or 'FAIL'
+    if detection was not possible.
+    """
+    retval = hostname()
+    if not retval:
+        return 'FAIL'
+    if '.' in retval:
+        return 'YES'
+    return 'NO'

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -58,6 +58,7 @@ download ceph container image:
 {% set bootstrap_ceph_conf = pillar['ceph-salt'].get('bootstrap_ceph_conf', {}) %}
 {% set bootstrap_ceph_conf_tmpfile = "/tmp/bootstrap-ceph.conf" %}
 {% set bootstrap_spec_yaml_tmpfile = "/tmp/bootstrap-spec.yaml" %}
+{% set my_hostname = salt['ceph_salt.hostname']() %}
 
 create static bootstrap yaml:
   cmd.run:
@@ -67,14 +68,14 @@ create static bootstrap yaml:
         echo -en "service_name: mgr\n" >> {{ bootstrap_spec_yaml_tmpfile }}
         echo -en "placement:\n" >> {{ bootstrap_spec_yaml_tmpfile }}
         echo -en "    hosts:\n" >> {{ bootstrap_spec_yaml_tmpfile }}
-        echo -en "        - '{{ grains['host'] }}'\n" >> {{ bootstrap_spec_yaml_tmpfile }}
+        echo -en "        - '{{ my_hostname }}'\n" >> {{ bootstrap_spec_yaml_tmpfile }}
         >> foo
         echo -en "---\n" >> {{ bootstrap_spec_yaml_tmpfile }}
         echo -en "service_type: mon\n" >> {{ bootstrap_spec_yaml_tmpfile }}
         echo -en "service_name: mon\n" >> {{ bootstrap_spec_yaml_tmpfile }}
         echo -en "placement:\n" >> {{ bootstrap_spec_yaml_tmpfile }}
         echo -en "    hosts:\n" >> {{ bootstrap_spec_yaml_tmpfile }}
-        echo -en "        - '{{ grains['host'] }}:{{ pillar['ceph-salt']['bootstrap_mon_ip'] }}'\n" >> {{ bootstrap_spec_yaml_tmpfile }}
+        echo -en "        - '{{ my_hostname }}:{{ pillar['ceph-salt']['bootstrap_mon_ip'] }}'\n" >> {{ bootstrap_spec_yaml_tmpfile }}
 
 create bootstrap ceph conf:
   cmd.run:
@@ -102,6 +103,7 @@ run cephadm bootstrap:
         CEPHADM_IMAGE={{ pillar['ceph-salt']['container']['images']['ceph'] }} \
         cephadm --verbose bootstrap \
                 --mon-ip {{ pillar['ceph-salt']['bootstrap_mon_ip'] }} \
+                --allow-fqdn-hostname \
                 --apply-spec {{ bootstrap_spec_yaml_tmpfile }} \
                 --config {{ bootstrap_ceph_conf_tmpfile }} \
 {%- if not pillar['ceph-salt']['dashboard']['password_update_required'] %}

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephorch.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephorch.sls
@@ -2,10 +2,12 @@
 
 {% if 'cephadm' in grains['ceph-salt']['roles'] %}
 
+{% set my_hostname = salt['ceph_salt.hostname']() %}
+
 {{ macros.begin_stage('Add host to ceph orchestrator') }}
 add host to ceph orch:
   ceph_orch.add_host:
-    - host: {{ grains['host'] }}
+    - host: {{ my_hostname }}
     - failhard: True
 {{ macros.end_stage('Add host to ceph orchestrator') }}
 

--- a/ceph-salt-formula/salt/ceph-salt/apply/software.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/software.sls
@@ -5,6 +5,7 @@
 install required packages:
   pkg.installed:
     - pkgs:
+      - hostname
       - iperf
       - iputils
       - lsof

--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -53,6 +53,7 @@ Requires:       python3-netaddr
 %endif
 
 Requires:       ceph-salt-formula
+Requires:       hostname
 Requires:       iperf
 Requires:       iputils
 Requires:       lsof

--- a/ceph_salt/core.py
+++ b/ceph_salt/core.py
@@ -21,7 +21,6 @@ class CephNode:
         self.minion_id = minion_id
         self._ipsv4 = None
         self._ipsv6 = None
-        self._hostname = None
         self._roles = None
         self._execution = None
         self._public_ip = None
@@ -41,13 +40,6 @@ class CephNode:
             result = GrainsManager.get_grain(self.minion_id, 'ipv6')
             self._ipsv6 = result[self.minion_id]
         return self._ipsv6
-
-    @property
-    def hostname(self):
-        if self._hostname is None:
-            result = GrainsManager.get_grain(self.minion_id, 'host')
-            self._hostname = result[self.minion_id]
-        return self._hostname
 
     @property
     def public_ip(self):


### PR DESCRIPTION
If *all* minions have FQDN environment, then use FQDN.

If *no* minions have FQDN environment, then use short hostname.

Otherwise (mixed FQDN/non-FQDN or could not determine), do not apply the
Salt Formula.

Fixes: https://github.com/ceph/ceph-salt/issues/417
Fixes: https://github.com/ceph/ceph-salt/issues/420
Signed-off-by: Nathan Cutler <ncutler@suse.com>