### PR TITLE
Optimize 'ceph-salt config' and 'ceph-salt status'

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -26,7 +26,7 @@ from .salt_utils import GrainsManager, PillarManager, CephOrch
 from .terminal_utils import PrettyPrinter as PP
 from .validate.config import validate_config
 from .validate.salt_master import check_salt_master_status, CephSaltPillarNotConfigured
-from .validate.salt_minion import sync_all
+from .validate.salt_minion import sync_modules
 
 
 logger = logging.getLogger(__name__)
@@ -1211,7 +1211,7 @@ class CephSaltConfigShell(configshell.ConfigShell):
         self._parser = parser
 
 
-def check_config_prerequesites():
+def check_config_prerequesites(sync_modules_target=None):
     try:
         check_salt_master_status()
     except CephSaltPillarNotConfigured:
@@ -1234,12 +1234,13 @@ base:
     - ceph-salt
 """)
             return False
-    sync_all()
+    if sync_modules_target:
+        sync_modules(sync_modules_target)
     return True
 
 
 def run_status():
-    if not check_config_prerequesites():
+    if not check_config_prerequesites(sync_modules_target='ceph-salt:roles:admin'):
         return False
     status = {}
     result = True
@@ -1263,7 +1264,7 @@ def run_status():
 
 
 def run_config_shell():
-    if not check_config_prerequesites():
+    if not check_config_prerequesites(sync_modules_target=None):
         return False
     shell = CephSaltConfigShell()
     generate_config_shell_tree(shell)
@@ -1278,7 +1279,7 @@ def run_config_shell():
 
 
 def run_config_cmdline(cmdline):
-    if not check_config_prerequesites():
+    if not check_config_prerequesites(sync_modules_target=None):
         return False
     shell = CephSaltConfigShell()
     generate_config_shell_tree(shell)

--- a/ceph_salt/validate/salt_master.py
+++ b/ceph_salt/validate/salt_master.py
@@ -19,12 +19,6 @@ class SaltMasterNotInstalled(ValidationException):
         super(SaltMasterNotInstalled, self).__init__('salt-master is not installed')
 
 
-class SaltMasterCommError(ValidationException):
-    def __init__(self, salt_exception_error):
-        super(SaltMasterCommError, self).__init__("Failed to communicate with salt-master: {}"
-                                                  .format(salt_exception_error))
-
-
 class NoPillarDirectoryConfigured(ValidationException):
     def __init__(self):
         super(NoPillarDirectoryConfigured, self).__init__(

--- a/ceph_salt/validate/salt_master.py
+++ b/ceph_salt/validate/salt_master.py
@@ -2,8 +2,6 @@ import logging
 import shutil
 import subprocess
 
-from salt.exceptions import SaltException
-
 from ..exceptions import ValidationException
 from ..salt_utils import SaltClient, PillarManager
 
@@ -55,17 +53,6 @@ def check_salt_master():
     raise NoSaltMasterProcess()
 
 
-def check_salt_master_communication():
-    try:
-        logger.info("running test.ping in salt-master")
-        result = SaltClient.caller(False).cmd('test.ping')
-        logger.info("test.ping result: %s", result)
-    except SaltException as ex:
-        logger.exception(ex)
-        logger.error("failed to run test.ping in salt-master")
-        raise SaltMasterCommError(str(ex))
-
-
 def check_ceph_salt_pillar():
     logger.info("checking if pillar directory is configured")
     if not SaltClient.pillar_fs_path():
@@ -80,5 +67,4 @@ def check_ceph_salt_pillar():
 
 def check_salt_master_status():
     check_salt_master()
-    check_salt_master_communication()
     check_ceph_salt_pillar()

--- a/ceph_salt/validate/salt_minion.py
+++ b/ceph_salt/validate/salt_minion.py
@@ -12,9 +12,25 @@ class UnableToSyncAll(ValidationException):
             "the problems reported")
 
 
+class UnableToSyncModules(ValidationException):
+    def __init__(self, target):
+        super(UnableToSyncModules, self).__init__(
+            "Sync failed, please run: "
+            "\"salt -G '{}' saltutil.sync_modules\" manually and fix "
+            "the problems reported".format(target))
+
+
 def sync_all():
     with contextlib.redirect_stdout(None):
         result = SaltClient.local_cmd('ceph-salt:member', 'saltutil.sync_all', tgt_type='grain')
     for minion, value in result.items():
         if not value:
             raise UnableToSyncAll()
+
+
+def sync_modules(target='ceph-salt:member'):
+    with contextlib.redirect_stdout(None):
+        result = SaltClient.local_cmd(target, 'saltutil.sync_modules', tgt_type='grain')
+    for value in result:
+        if not value:
+            raise UnableToSyncModules(target)

--- a/tests/test_validate_salt_master.py
+++ b/tests/test_validate_salt_master.py
@@ -1,11 +1,10 @@
 import subprocess
 
 from mock import patch
-from salt.exceptions import SaltException
 
 from ceph_salt.validate.salt_master import check_salt_master, SaltMasterNotInstalled, \
-    NoSaltMasterProcess, SaltMasterCommError, check_salt_master_communication, \
-    check_ceph_salt_pillar, NoPillarDirectoryConfigured, CephSaltPillarNotConfigured
+    NoSaltMasterProcess, check_ceph_salt_pillar, NoPillarDirectoryConfigured, \
+    CephSaltPillarNotConfigured
 
 from . import SaltMockTestCase
 
@@ -42,19 +41,6 @@ class ValidateSaltMasterTest(SaltMockTestCase):
     @patch('subprocess.check_output', return_value="1")
     def test_salt_master_ok(self, *args):
         check_salt_master()
-
-    def test_salt_master_comm_ping(self):
-        def cmd(*args, **kwargs):
-            raise SaltException('testing')
-        self.caller_client.cmd = cmd
-
-        with self.assertRaises(SaltMasterCommError) as ctx:
-            check_salt_master_communication()
-
-        self.assertEqual(str(ctx.exception), "Failed to communicate with salt-master: testing")
-
-    def test_salt_master_comm_ok(self):
-        check_salt_master_communication()
 
     def test_ceph_salt_pillar_directory(self):
         self.master_config.opts = {}


### PR DESCRIPTION
Optimizations:
- The `salt-master` communication check relies on `salt-call`, which is very slow, so this PR will remove this check
- `ceph-salt config` don't rely on any ceph-salt salt module/state, so no need to run `sync_all`
- `ceph-salt status` only rely on ceph-salt salt modules so we just need to `sync_modules` instead of `sync_all`
- `ceph-salt status` only use use admin minions, so we just need to sync modules on `-G ceph-salt:roles:admin` instead of `-G ceph-salt:member`

**BEFORE**
```
master:~ # time ceph-salt config /

real	0m5.180s
user	0m3.688s
sys	0m0.206s
master:~ # time ceph-salt config /

real	0m5.404s
user	0m3.779s
sys	0m0.219s
```

**AFTER REMOVING MASTER COMMUNICATION CHECK**
```
master:~ # time ceph-salt config /

real	0m2.184s
user	0m0.757s
sys	0m0.078s
master:~ # time ceph-salt config /

real	0m2.161s
user	0m0.796s
sys	0m0.070s
```

**AFTER REMOVING MASTER COMMUNICATION CHECK and SYNC_ALL**
```
master:~ # time ceph-salt config /

real	0m0.989s
user	0m0.669s
sys	0m0.056s
master:~ # time ceph-salt config /

real	0m0.973s
user	0m0.651s
sys	0m0.074s
```