### PR TITLE
Fix salt warning on 'ceph-salt status'

### DIFF
--- a/ceph_salt/salt_utils.py
+++ b/ceph_salt/salt_utils.py
@@ -330,9 +330,10 @@ class CephOrch:
 
     @staticmethod
     def host_ls():
-        result = SaltClient.local_cmd('ceph-salt:roles:admin', 'ceph_orch.configured',
-                                      full_return=True,
-                                      tgt_type='grain')
+        with contextlib.redirect_stdout(None):
+            result = SaltClient.local_cmd('ceph-salt:roles:admin', 'ceph_orch.configured',
+                                          full_return=True,
+                                          tgt_type='grain')
         for minion, value in result.items():
             if value.get('retcode') > 0:
                 raise CephSaltException("Failed to check if ceph orch is configured "
@@ -348,9 +349,10 @@ class CephOrch:
 
     @staticmethod
     def deployed():
-        result = SaltClient.local_cmd('ceph-salt:roles:admin', 'ceph_orch.ceph_configured',
-                                      full_return=True,
-                                      tgt_type='grain')
+        with contextlib.redirect_stdout(None):
+            result = SaltClient.local_cmd('ceph-salt:roles:admin', 'ceph_orch.ceph_configured',
+                                          full_return=True,
+                                          tgt_type='grain')
         for minion, value in result.items():
             if value.get('retcode') > 0:
                 raise CephSaltException("Failed to check if ceph is configured "


### PR DESCRIPTION
If no admin minions are yet set in `ceph-salt config`, we get the following warning when executing `ceph-salt status`:
```
master:~ # ceph-salt status
No minions matched the target. No command was sent, no jid was assigned.
No minions matched the target. No command was sent, no jid was assigned.
cluster: 0 minions, 0 hosts managed by cephadm
config:  No bootstrap minion specified in config
```

With this PR we will get:
```
master:~ # ceph-salt status
cluster: 0 minions, 0 hosts managed by cephadm
config:  No bootstrap minion specified in config
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>