### PR TITLE
Optimize 'ceph-salt config' minion add

### DIFF
--- a/ceph_salt/core.py
+++ b/ceph_salt/core.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import os
 import base64
 import hashlib
 
@@ -166,7 +167,7 @@ class CephNodeManager:
 
     @classmethod
     def list_all_minions(cls):
-        return SaltClient.caller().cmd('minion.list')['minions']
+        return os.listdir(SaltClient.pki_minions_fs_path())
 
     @staticmethod
     def all_roles(ceph_salt_node):

--- a/ceph_salt/salt_utils.py
+++ b/ceph_salt/salt_utils.py
@@ -54,6 +54,11 @@ class SaltClient:
         return pillar_dirs[0]
 
     @classmethod
+    def pki_minions_fs_path(cls):
+        pki_dir = cls._opts().get('pki_dir', '/etc/salt/pki/master')
+        return '{}/minions'.format(pki_dir)
+
+    @classmethod
     def local_cmd(cls, target, func, args=None, tgt_type='glob', full_return=False):
         """
         Equal to `local().cmd(...)`, but with proper error checking.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -262,6 +262,10 @@ class SaltMockTestCase(TestCase):
     def states_fs_path():
         return '/srv/salt'
 
+    @staticmethod
+    def pki_minions_fs_path():
+        return '/etc/salt/pki/master/minions'
+
     def setUp(self):
         super(SaltMockTestCase, self).setUp()
         self.setUpPyfakefs()
@@ -292,6 +296,7 @@ class SaltMockTestCase(TestCase):
             self.addCleanup(patcher.stop)
         self.fs.create_dir(self.pillar_fs_path())
         self.fs.create_dir(self.states_fs_path())
+        self.fs.create_dir(self.pki_minions_fs_path())
         self.fs.create_file(os.path.join(self.pillar_fs_path(), 'ceph-salt.sls'))
 
     def tearDown(self):

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -20,6 +20,8 @@ class ConfigShellTest(SaltMockTestCase):
         generate_config_shell_tree(self.shell)
 
         self.salt_env.minions = ['node1.ceph.com', 'node2.ceph.com', 'node3.ceph.com']
+        for minion in self.salt_env.minions:
+            self.fs.create_file('{}/{}'.format(self.pki_minions_fs_path(), minion))
         GrainsManager.set_grain('node1.ceph.com', 'fqdn_ip4', ['10.20.39.201'])
         GrainsManager.set_grain('node2.ceph.com', 'fqdn_ip4', ['10.20.39.202'])
         GrainsManager.set_grain('node3.ceph.com', 'fqdn_ip4', ['10.20.39.203'])
@@ -27,6 +29,8 @@ class ConfigShellTest(SaltMockTestCase):
     def tearDown(self):
         super(ConfigShellTest, self).tearDown()
         PillarManager.reload()
+        for minion in self.salt_env.minions:
+            self.fs.remove_object('{}/{}'.format(self.pki_minions_fs_path(), minion))
 
     def test_ceph_cluster_minions(self):
         self.shell.run_cmdline('/ceph_cluster/minions add node1.ceph.com')


### PR DESCRIPTION
Executing `salt-call` commands is really slow, so we are now reading the list of minions from  `/etc/salt/pki/master/minions` directory instead of using a salt-call:

```
master:~ # time salt-call minion.list
local:
    ----------
    minions:
        - master.octopus.test
        - node1.octopus.test
        - node2.octopus.test
        - node3.octopus.test
    minions_denied:
    minions_pre:
    minions_rejected:

real	0m3.663s
user	0m3.301s
sys	0m0.194s
```
```
master:~ # time ls -1 /etc/salt/pki/master/minions
master.octopus.test
node1.octopus.test
node2.octopus.test
node3.octopus.test

real	0m0.003s
user	0m0.001s
sys	0m0.003s
```

So adding a new minion to the ceph-salt config is now faster:

**Before**
```
master:~ # time ceph-salt config /ceph_cluster/minions add node3.ses7.test
Adding node3.ses7.test...
1 minion added.

real	0m7.344s
user	0m4.048s
sys	0m0.187s

master:~ # time ceph-salt config /ceph_cluster/minions add node3.ses7.test
No minions added.

real	0m4.167s
user	0m3.691s
sys	0m0.163s
```


**After**
```
master:~ # time ceph-salt config /ceph_cluster/minions add node3.ses7.test
Adding node3.ses7.test...
1 minion added.

real	0m3.855s
user	0m1.063s
sys	0m0.103s

master:~ # time ceph-salt config /ceph_cluster/minions add node3.ses7.test
No minions added.

real	0m1.024s
user	0m0.654s
sys	0m0.083s
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>