### PR TITLE
Inform user when default values are being populated

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -1140,6 +1140,22 @@ class MinionsOptionNode(OptionNode):
         return matching
 
 
+class SingleMsgPrinter():
+    """
+    Each message will only be printed one time
+    """
+
+    POPULATING_DEFAULT_VALUES = 'Populating default values...'
+
+    _printed = []
+
+    @classmethod
+    def print(cls, msg):
+        if msg not in cls._printed:
+            PP.println(msg)
+            cls._printed.append(msg)
+
+
 def _generate_option_node(option_name, option_dict, parent):
     if option_dict.get('type', None) == 'group':
         _generate_group_node(option_name, option_dict, parent)
@@ -1152,6 +1168,7 @@ def _generate_option_node(option_name, option_dict, parent):
 
     # persist default values
     if handler and handler.default() is not None and handler.value()[0] is None:
+        SingleMsgPrinter.print(SingleMsgPrinter.POPULATING_DEFAULT_VALUES)
         handler.save(handler.default())
 
     if option_dict.get('type', None) == 'flag':
@@ -1178,6 +1195,7 @@ def _generate_group_node(group_name, group_dict, parent):
 
     # persist default values
     if handler and handler.default() is not None and handler.value()[0] is None:
+        SingleMsgPrinter.print(SingleMsgPrinter.POPULATING_DEFAULT_VALUES)
         handler.save(handler.default())
 
     for option_name, option_dict in group_dict['options'].items():


### PR DESCRIPTION
When `/srv/pillar/ceph-salt.sls` does not exist yet, or when it misses any default value, `ceph-salt` will populate it with missing default values.

This typically happens on the first `ceph-salt config` execution, making the **first execution much slower than other executions**.

Displaying a message, e.g. `Populating default values...`, informing the user what's happening should be sufficient to make it clear that first execution is taking longer:


```
master:~ # cat /srv/pillar/ceph-salt.sls 
ceph-salt:
  container:
    registries_enabled: true
  dashboard:
    password: ocbgf9joz3
    password_update_required: true
    username: admin
  time_server:
    enabled: true

master:~ # time ceph-salt config /

real	0m0.955s
user	0m0.666s
sys	0m0.072s

master:~ # rm /srv/pillar/ceph-salt.sls

master:~ # time ceph-salt config /
Populating default values...

real	0m3.666s
user	0m0.969s
sys	0m0.137s

master:~ # time ceph-salt config /

real	0m0.951s
user	0m0.625s
sys	0m0.108s

```


Signed-off-by: Ricardo Marques <rimarques@suse.com>