### PR TITLE
Pillar targeting by minion id instead of grain

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/init.sls
@@ -1,4 +1,4 @@
-{% if 'ceph-salt' in grains and grains['ceph-salt']['member'] %}
+{% if grains['id'] in pillar['ceph-salt']['minions']['all'] %}
 
 include:
     - ..reset

--- a/ceph-salt-formula/salt/ceph-salt/purge/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/purge/init.sls
@@ -1,4 +1,4 @@
-{% if 'ceph-salt' in grains and grains['ceph-salt']['member'] %}
+{% if grains['id'] in pillar['ceph-salt']['minions']['all'] %}
 
 check safety:
    ceph_salt.check_safety:

--- a/ceph-salt-formula/salt/ceph-salt/reboot/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/reboot/init.sls
@@ -1,4 +1,4 @@
-{% if 'ceph-salt' in grains and grains['ceph-salt']['member'] %}
+{% if grains['id'] in pillar['ceph-salt']['minions']['all'] %}
 
 include:
     - ..reset

--- a/ceph-salt-formula/salt/ceph-salt/stop/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/stop/init.sls
@@ -1,4 +1,4 @@
-{% if 'ceph-salt' in grains and grains['ceph-salt']['member'] %}
+{% if grains['id'] in pillar['ceph-salt']['minions']['all'] %}
 
 include:
     - ..reset

--- a/ceph-salt-formula/salt/ceph-salt/update/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/update/init.sls
@@ -1,4 +1,4 @@
-{% if 'ceph-salt' in grains and grains['ceph-salt']['member'] %}
+{% if grains['id'] in pillar['ceph-salt']['minions']['all'] %}
 
 include:
     - ..reset

--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -99,8 +99,18 @@ mkdir -p %{buildroot}%{_datadir}/%{fname}/pillar
 # pillar top sls file
 cat <<EOF > %{buildroot}%{_datadir}/%{fname}/pillar/top.sls
 base:
-    '*':
+{% include 'ceph-salt-top.sls' %}
+EOF
+
+# ceph-salt pillar top sls file
+cat <<EOF > %{buildroot}%{_datadir}/%{fname}/pillar/ceph-salt-top.sls
+{% import_yaml "ceph-salt.sls" as ceph_salt %}
+{% set ceph_salt_minions = ceph_salt.get('ceph-salt', {}).get('minions', {}).get('all', []) %}
+{% if ceph_salt_minions %}
+  {{ ceph_salt_minions|join(',') }}:
+    - match: list
     - ceph-salt
+{% endif %}
 EOF
 
 # empty ceph-salt.sls file
@@ -151,6 +161,7 @@ Salt Formula to deploy Ceph clusters.
 %dir %attr(0755, salt, salt) %{_datadir}/%{fname}/pillar
 %doc %attr(0644, salt, salt) %{_datadir}/%{fname}/pillar.conf.example
 %attr(0600, salt, salt) %{_datadir}/%{fname}/pillar/ceph-salt.sls
+%attr(0644, salt, salt) %{_datadir}/%{fname}/pillar/ceph-salt-top.sls
 %attr(0644, salt, salt) %{_datadir}/%{fname}/pillar/top.sls
 %{fdir}/states/
 %{fdir}/metadata/

--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -18,7 +18,6 @@ from .core import CephNodeManager, SshKeyManager, CephNode
 from .exceptions import (
     CephSaltException,
     MinionDoesNotExistInConfiguration,
-    PillarFileNotPureYaml,
     ParamsException
 )
 from .params_helper import BooleanStringValidator, BooleanStringTransformer
@@ -1233,25 +1232,8 @@ def check_config_prerequesites(sync_modules_target=None):
     try:
         check_salt_master_status()
     except CephSaltPillarNotConfigured:
-        try:
-            PillarManager.install_pillar()
-        except PillarFileNotPureYaml:
-            PP.println("""
-ceph-salt pillar file is not installed yet, and we can't add it automatically
-because pillar's top.sls is probably using Jinja2 expressions.
-Please create a ceph-salt.sls file in salt's pillar directory with the following
-content:
-
-ceph-salt: {}
-
-and add the following pillar configuration to top.sls file:
-
-base:
-  'ceph-salt:member':
-    - match: grain
-    - ceph-salt
-""")
-            return False
+        PP.println('Configuring ceph-salt pillar...')
+        PillarManager.install_pillar()
     if sync_modules_target:
         sync_modules(sync_modules_target)
     return True


### PR DESCRIPTION
Overview
---
The `ceph-salt` pillar contains sensitive data (e.g., SSH private key), so we need to guarantee that only minions allowed to consume that information will be able to access it.

The problem
---
Until this PR, `ceph-salt` was using grain targetting to distribute the `ceph-salt` pillar:

```
# cat top.sls
base:	
  'ceph-salt:member':	
    - match: grain	
    - ceph-salt
```
Since grains can be set by the minions, nothing prevents a non-ceph-salt minion, registered to the same salt master, from setting the `ceph-salt:member grain` and access the `ceph-salt pillar` without "permission".

Example:
```
# cat /etc/salt/grains
cat: /etc/salt/grains: No such file or directory

# salt-call pillar.items
local:
    ----------


# printf "ceph-salt:\n  member: true" > /etc/salt/grains

# salt-call pillar.items
local:
    ----------
    ceph-salt:
        ----------
        bootstrap_ceph_conf:
            ----------
            global:
                ----------
                cluster_network:
                    192.168.200.0/24
< -- cut -->
```

The solution
---
The only grain that is considerer secure to use is the `id`, because changing that grain requires the master to re-accept the minion key, so we are now using minion `id` targetting to distribute `ceph-salt` pillar:

```
master:/srv/pillar # cat top.sls 
base:
{% include 'ceph-salt-top.sls' %}

master:/srv/pillar # cat ceph-salt-top.sls 
{% import_yaml "ceph-salt.sls" as ceph_salt %}
{% set ceph_salt_minions = ceph_salt.get('ceph-salt', {}).get('minions', {}).get('all', []) %}
{% if ceph_salt_minions %}
  {{ ceph_salt_minions|join(',') }}:
    - match: list
    - ceph-salt
{% endif %}
```
Which will guarantee that only minions listed in `ceph-salt:minions:all` pillar will be able to read `ceph-salt` pillar.


Signed-off-by: Ricardo Marques <rimarques@suse.com>