### PR TITLE
Do not create ceph-salt pillar file during installation

### DIFF
--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -94,38 +94,6 @@ mkdir -p %{buildroot}%{fdir}/metadata/%{fname}/
 cp -R ceph-salt-formula/salt/* %{buildroot}%{fdir}/states/
 cp ceph-salt-formula/metadata/* %{buildroot}%{fdir}/metadata/%{fname}/
 
-mkdir -p %{buildroot}%{_datadir}/%{fname}/pillar
-
-# pillar top sls file
-cat <<EOF > %{buildroot}%{_datadir}/%{fname}/pillar/top.sls
-base:
-{% include 'ceph-salt-top.sls' %}
-EOF
-
-# ceph-salt pillar top sls file
-cat <<EOF > %{buildroot}%{_datadir}/%{fname}/pillar/ceph-salt-top.sls
-{% import_yaml "ceph-salt.sls" as ceph_salt %}
-{% set ceph_salt_minions = ceph_salt.get('ceph-salt', {}).get('minions', {}).get('all', []) %}
-{% if ceph_salt_minions %}
-  {{ ceph_salt_minions|join(',') }}:
-    - match: list
-    - ceph-salt
-{% endif %}
-EOF
-
-# empty ceph-salt.sls file
-cat <<EOF > %{buildroot}%{_datadir}/%{fname}/pillar/ceph-salt.sls
-ceph-salt:
-
-EOF
-
-cat <<EOF > %{buildroot}%{_datadir}/%{fname}/pillar.conf.example
-pillar_roots:
-    base:
-    - /srv/pillar
-    - %{_datadir}/%{fname}/pillar
-EOF
-
 
 %files
 %license LICENSE
@@ -157,12 +125,6 @@ Salt Formula to deploy Ceph clusters.
 %dir %attr(0755, root, salt) %{fdir}/
 %dir %attr(0755, root, salt) %{fdir}/states/
 %dir %attr(0755, root, salt) %{fdir}/metadata/
-%dir %attr(0755, root, root) %{_datadir}/%{fname}
-%dir %attr(0755, salt, salt) %{_datadir}/%{fname}/pillar
-%doc %attr(0644, salt, salt) %{_datadir}/%{fname}/pillar.conf.example
-%attr(0600, salt, salt) %{_datadir}/%{fname}/pillar/ceph-salt.sls
-%attr(0644, salt, salt) %{_datadir}/%{fname}/pillar/ceph-salt-top.sls
-%attr(0644, salt, salt) %{_datadir}/%{fname}/pillar/top.sls
 %{fdir}/states/
 %{fdir}/metadata/
 


### PR DESCRIPTION
Files that will be edited by the user should not be created during package installation, otherwise, they will be overridden during package update:

```
master:~ # rpm -q ceph-salt-formula
ceph-salt-formula-15.2.13+1602621538.ga6a6c18-lp152.3.1.noarch

master:~ # cat /usr/share/ceph-salt/pillar/ceph-salt.sls
ceph-salt:
  test: 123

master:~ # zypper up ceph-salt-formula
...

master:~ # rpm -q ceph-salt-formula
ceph-salt-formula-15.2.13+1602623476.ga6a6c18-lp152.4.1.noarch

master:~ # cat /usr/share/ceph-salt/pillar/ceph-salt.sls
ceph-salt:

master:~ #
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>