### PR TITLE
apply: Ensure mgr/cephadm/container_init is set to true

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
@@ -17,6 +17,7 @@ configure cephadm mgr module:
 {%- endif %}
         ceph config set mgr mgr/cephadm/manage_etc_ceph_ceph_conf true
         ceph config set mgr mgr/cephadm/use_repo_digest true --force
+        ceph config set mgr mgr/cephadm/container_init true
     - failhard: True
 
 {{ macros.end_stage('Ensure cephadm MGR module is configured') }}


### PR DESCRIPTION
By default, the "mgr/cephadm" orchestrator does not provide the "--init"
option when starting containers. It can by made to do this, though, by
explicitly setting an option ("mgr/cephadm/container_init").

On freshly deployed SES7 clusters, this option will have already been
set by "cephadm bootstrap --container-init", in which case this line
will be a noop. But it is still needed for upgraded clusters.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1177588
Signed-off-by: Nathan Cutler <ncutler@suse.com>