### PR TITLE
Support multiple time servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ sync its clock against one or more external servers (e.g. "pool.ntp.org"), and
 all other nodes in the cluster will sync their clocks against this node:
 
 ```
-/time_server/server_hostname set <minion id of the admin node>
+/time_server/servers add <minion id of the admin node>
 /time_server/external_servers add pool.ntp.org
 ```
 
@@ -118,7 +118,7 @@ can be useful when setting up a cluster at a site that already has a single
 source of time:
 
 ```
-/time_server/server_hostname set <hostname>
+/time_server/servers add <hostname>
 ```
 
 (In this case, the on-site time server is assumed to be already configured and

--- a/ceph-salt-formula/salt/ceph-salt/apply/files/chrony.conf.j2
+++ b/ceph-salt-formula/salt/ceph-salt/apply/files/chrony.conf.j2
@@ -1,14 +1,16 @@
 # {% include "ceph-salt/apply/files/managed-header.txt.j2" ignore missing %}
-{%- set time_server = pillar['ceph-salt']['time_server']['server_host'] %}
-{%- if grains['id'] == time_server %}
+{%- set time_servers = pillar['ceph-salt']['time_server']['server_hosts'] %}
+{%- if grains['id'] in time_servers %}
 {%- for server in pillar['ceph-salt']['time_server'].get('external_time_servers', []) %}
 pool {{ server }} iburst
 {%- endfor %}
 
 allow {{ pillar['ceph-salt']['time_server']['subnet'] }}
-{%- else %}    {# grains['id'] == time_server #}
+{%- else %}    {# grains['id'] in (time_servers) #}
+{%- for time_server in time_servers %}
 server {{ time_server }} iburst
-{%- endif %}   {# grains['id'] == time_server #}
+{%- endfor %}
+{%- endif %}   {# grains['id'] in (time_servers) #}
 
 driftfile /var/lib/chrony/drift
 makestep 0.1 3

--- a/ceph-salt-formula/salt/ceph-salt/apply/time-sync.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/time-sync.sls
@@ -1,5 +1,5 @@
 {% if pillar['ceph-salt']['time_server']['enabled'] %}
-{% set time_server = pillar['ceph-salt']['time_server']['server_host'] %}
+{% set time_server = pillar['ceph-salt']['time_server']['server_hosts'][0] %}
 {% set time_server_is_minion = time_server in pillar['ceph-salt']['minions']['all'] %}
 
 {% import 'macros.yml' as macros %}
@@ -23,7 +23,7 @@
 wait for time server sync:
   ceph_salt.wait_for_grain:
     - grain: ceph-salt:execution:timeserversynced
-    - hosts: [ {{ pillar['ceph-salt']['time_server']['server_host'] }} ]
+    - hosts: [ {{ time_server }} ]
     - failhard: True
 {{ macros.end_step('Wait for time server node to signal that it has synced its clock') }}
 

--- a/ceph-salt-formula/salt/ceph-salt/reset.sls
+++ b/ceph-salt-formula/salt/ceph-salt/reset.sls
@@ -17,3 +17,8 @@ reset stopped:
   grains.present:
     - name: ceph-salt:execution:stopped
     - value: False
+
+reset stoptimeserversyncedped:
+  grains.present:
+    - name: ceph-salt:execution:timeserversynced
+    - value: False

--- a/ceph_salt/execute.py
+++ b/ceph_salt/execute.py
@@ -1474,8 +1474,9 @@ class CephSaltExecutor:
         return retval
 
     @staticmethod
-    def check_external_time_servers(ts_minion, external_ts_list):
-        PP.println("Installing python3-ntplib on time server node...")
+    def check_external_time_servers(ts_minions, external_ts_list):
+        ts_minion = ts_minions[0]
+        PP.println("Installing python3-ntplib on {}...".format(ts_minion))
         salt_result = SaltClient.local().cmd(
             ts_minion, 'pkg.install', ["name='python3-ntplib'", "refresh=True"]
         )
@@ -1614,11 +1615,11 @@ class CephSaltExecutor:
         if state in ['ceph-salt', 'ceph-salt.apply']:
             time_server_enabled = PillarManager.get('ceph-salt:time_server:enabled')
             if time_server_enabled:
-                time_server_host = PillarManager.get('ceph-salt:time_server:server_host')
+                time_server_hosts = PillarManager.get('ceph-salt:time_server:server_hosts')
                 ext_time_servers = PillarManager.get('ceph-salt:time_server:external_time_servers')
                 if ext_time_servers:
                     retcode = CephSaltExecutor.check_external_time_servers(
-                        time_server_host,
+                        time_server_hosts,
                         ext_time_servers
                     )
                     if retcode > 0:

--- a/ceph_salt/validate/config.py
+++ b/ceph_salt/validate/config.py
@@ -89,10 +89,10 @@ def validate_config(deployed, ceph_nodes):
     if not isinstance(time_server_enabled, bool):
         return "'ceph-salt:time_server:enabled' must be of type Boolean"
     if time_server_enabled:
-        time_server_host = PillarManager.get('ceph-salt:time_server:server_host')
-        if not time_server_host:
+        time_server_hosts = PillarManager.get('ceph-salt:time_server:server_hosts')
+        if not time_server_hosts:
             return 'No time server host specified in config'
-        time_server_is_minion = time_server_host in all_minions
+        time_server_is_minion = any(tsh in all_minions for tsh in time_server_hosts)
         time_server_subnet = PillarManager.get('ceph-salt:time_server:subnet')
         not_minion_err = ('Time server is not a minion: {} '
                           'setting will not have any effect')

--- a/tests/test_config_shell.py
+++ b/tests/test_config_shell.py
@@ -233,13 +233,13 @@ class ConfigShellTest(SaltMockTestCase):
                               'ceph-salt:time_server:external_time_servers',
                               ['server1', 'server2'])
 
-    def test_time_server_server_hostname(self):
+    def test_time_server_servers(self):
         self.shell.run_cmdline('/ceph_cluster/minions add node1.ceph.com')
         self.clearSysOut()
 
-        self.assertValueOption('/time_server/server_hostname',
-                               'ceph-salt:time_server:server_host',
-                               'node1.ceph.com')
+        self.assertListOption('/time_server/servers',
+                              'ceph-salt:time_server:server_hosts',
+                              ['node1.ceph.com'])
 
         self.shell.run_cmdline('/ceph_cluster/minions remove node1.ceph.com')
 
@@ -254,7 +254,7 @@ class ConfigShellTest(SaltMockTestCase):
         self.shell.run_cmdline('/ceph_cluster/roles/cephadm add node1.ceph.com')
         self.shell.run_cmdline('/ceph_cluster/roles/cephadm add node2.ceph.com')
         self.shell.run_cmdline('/ceph_cluster/roles/admin add node1.ceph.com')
-        self.shell.run_cmdline('/time_server/server_hostname set node1.ceph.com')
+        self.shell.run_cmdline('/time_server/servers add node1.ceph.com')
         self.shell.run_cmdline('/time_server/subnet set 10.20.188.0/24')
         self.clearSysOut()
 
@@ -277,12 +277,12 @@ class ConfigShellTest(SaltMockTestCase):
             },
             'time_server': {
                 'enabled': True,
-                'server_host': 'node1.ceph.com',
+                'server_hosts': ['node1.ceph.com'],
                 'subnet': '10.20.188.0/24'
             }})
 
         self.shell.run_cmdline('/time_server/subnet reset')
-        self.shell.run_cmdline('/time_server/server_hostname reset')
+        self.shell.run_cmdline('/time_server/servers reset')
         self.shell.run_cmdline('/ceph_cluster/roles/admin remove node1.ceph.com')
         self.shell.run_cmdline('/ceph_cluster/roles/cephadm remove node2.ceph.com')
         self.shell.run_cmdline('/ceph_cluster/roles/cephadm remove node1.ceph.com')
@@ -299,7 +299,7 @@ class ConfigShellTest(SaltMockTestCase):
                 'throughput': []
             },
             'time_server': {
-                'server_host': 'node1.ceph.com',
+                'server_hosts': ['node1.ceph.com'],
                 'subnet': '10.20.188.0/24'
             }}))
         self.assertTrue(run_import("/config.json"))
@@ -319,11 +319,12 @@ class ConfigShellTest(SaltMockTestCase):
         self.assertEqual(PillarManager.get('ceph-salt:minions:cephadm'), [])
         self.assertEqual(PillarManager.get('ceph-salt:minions:throughput'), [])
         self.assertIsNone(PillarManager.get('ceph-salt:bootstrap_minion'))
-        self.assertEqual(PillarManager.get('ceph-salt:time_server:server_host'), 'node1.ceph.com')
+        self.assertEqual(PillarManager.get('ceph-salt:time_server:server_hosts'),
+                         ['node1.ceph.com'])
         self.assertEqual(PillarManager.get('ceph-salt:time_server:subnet'), '10.20.188.0/24')
 
         self.shell.run_cmdline('/time_server/subnet reset')
-        self.shell.run_cmdline('/time_server/server_hostname reset')
+        self.shell.run_cmdline('/time_server/servers reset')
         self.shell.run_cmdline('/ceph_cluster/roles/admin remove node1.ceph.com')
         self.shell.run_cmdline('/ceph_cluster/minions remove node2.ceph.com')
         self.shell.run_cmdline('/ceph_cluster/minions remove node1.ceph.com')

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -88,7 +88,7 @@ PBVw2pLCZsH5ol3VJ1/DETsGRMzFubFeTUNOC3MzhhG+V"""
         self.assertValidateConfig("'ceph-salt:time_server:enabled' must be of type Boolean")
 
     def test_no_time_server_host(self):
-        PillarManager.reset('ceph-salt:time_server:server_host')
+        PillarManager.reset('ceph-salt:time_server:server_hosts')
         self.assertValidateConfig("No time server host specified in config")
 
     def test_no_time_server_subnet(self):
@@ -102,7 +102,7 @@ PBVw2pLCZsH5ol3VJ1/DETsGRMzFubFeTUNOC3MzhhG+V"""
     def test_time_server_not_a_minion(self):
         not_minion_err = ('Time server is not a minion: {} '
                           'setting will not have any effect')
-        PillarManager.set('ceph-salt:time_server:server_host', 'foo.example.com')
+        PillarManager.set('ceph-salt:time_server:server_hosts', ['foo.example.com'])
         PillarManager.reset('ceph-salt:time_server:external_time_servers')
         self.assertValidateConfig(not_minion_err.format('time server subnet'))
         PillarManager.reset('ceph-salt:time_server:subnet')
@@ -259,7 +259,7 @@ SCzirUzUKN2oge2WieNI7MQ=
         PillarManager.set('ceph-salt:bootstrap_minion', 'node1.ceph.com')
         PillarManager.set('ceph-salt:bootstrap_mon_ip', '10.20.188.201')
         PillarManager.set('ceph-salt:time_server:enabled', True)
-        PillarManager.set('ceph-salt:time_server:server_host', 'node1.ceph.com')
+        PillarManager.set('ceph-salt:time_server:server_hosts', ['node1.ceph.com'])
         PillarManager.set('ceph-salt:time_server:external_time_servers', ['pool.ntp.org'])
         PillarManager.set('ceph-salt:time_server:subnet', '10.20.188.0/24')
         PillarManager.set('ceph-salt:minions:all', ['node1.ceph.com',


### PR DESCRIPTION
With this PR, it will be possible to specify multiple time servers:

```
master:~ # ceph-salt config /time_server ls
o- time_server ....................................................... [enabled]
  o- external_servers ...................................................... [1]
  | o- pool.ntp.org ...................................................... [...]
  o- servers ............................................................... [2]
  | o- node1.ses7.test ................................................... [...]
  | o- node2.ses7.test ................................................... [...]
  o- subnet ................................................... [10.20.147.0/24]
```

Note that this PR changes pillar structure, but `ceph-salt` does not support automatic pillar structure updates yet, which means that if you are upgrading from a previous `ceph-salt` version you need to re-configure timeserver or do the following replace in `/srv/pillar/ceph-salt.sls` manually:

**Before:**
```
server_hosts: <host>
```
**After:**
```
server_hosts:
- <host>
```

The config node was renamed too:
**Before:**
```
> /time_server/server_hostname
```
**After:**
```
> /time_server/servers
```


Fixes: https://github.com/ceph/ceph-salt/issues/426

Signed-off-by: Ricardo Marques <rimarques@suse.com>