### PR TITLE
Drop the `container-init` flag during bootstrap

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -106,7 +106,6 @@ run cephadm bootstrap:
                 --allow-fqdn-hostname \
                 --apply-spec {{ bootstrap_spec_yaml_tmpfile }} \
                 --config {{ bootstrap_ceph_conf_tmpfile }} \
-                --container-init \
 {%- if not pillar['ceph-salt']['dashboard']['password_update_required'] %}
                 --dashboard-password-noupdate \
 {%- endif %}


### PR DESCRIPTION
cephadm will now start containers using an init process by default

After: https://github.com/ceph/ceph/pull/37764

Signed-off-by: Michael Fritch <mfritch@suse.com>