### PR TITLE
spec: peg version of ceph-salt-formula RPM

### DIFF
--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -53,7 +53,7 @@ Requires:       python3-netaddr
 %endif
 
 Requires:       catatonit
-Requires:       ceph-salt-formula
+Requires:       ceph-salt-formula = %{version}
 Requires:       hostname
 Requires:       iperf
 Requires:       iputils


### PR DESCRIPTION
Since ceph-salt RPM and ceph-salt-formula RPM both come from the same "source
RPM", it makes sense to peg the ceph-salt-formula version so it gets upgraded at
the same time as ceph-salt.

Please note that, in OBS/IBS, the macro `%{version}` will expand to something like this:
    
    15.2.14+1603183994.g323e812
    
which should be sufficient to lock in the correct Salt Formula code.

Fixes: https://github.com/ceph/ceph-salt/issues/427
Signed-off-by: Nathan Cutler <ncutler@suse.com>