### PR TITLE
config_shell: remove 0-length prefs.bin before init and handle init failure

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -4,6 +4,7 @@ import itertools
 import logging
 import fnmatch
 import json
+import os
 from pathlib import Path
 import random
 import string
@@ -1227,8 +1228,20 @@ def generate_config_shell_tree(shell):
 class CephSaltConfigShell(configshell.ConfigShell):
     # pylint: disable=anomalous-backslash-in-string
     def __init__(self):
-        super(CephSaltConfigShell, self).__init__(
-            '~/.ceph_salt_config_shell')
+        #
+        # before initializing configshell_fb, check for zero-length prefs.bin
+        configshell_path = os.path.expanduser('~/.ceph_salt_config_shell')
+        prefs_bin_path = '{}/prefs.bin'.format(configshell_path)
+        if os.path.exists(prefs_bin_path):
+            logger.debug('%s exists', prefs_bin_path)
+            prefs_bin_filesize = os.path.getsize(prefs_bin_path)
+            if prefs_bin_filesize == 0:
+                logger.warning('%s has size 0; removing!', prefs_bin_path)
+                os.remove(prefs_bin_path)
+        else:
+            logger.debug('%s does not exist', prefs_bin_path)
+        super(CephSaltConfigShell, self).__init__(configshell_path)
+        #
         # Grammar of the command line
         command = locatedExpr(Word(alphanums + '_'))('command')
         var = QuotedString('"') | QuotedString("'") | Word(alphanums + '?;&*$!#,=_\+/.<>()~@:-%[]')

--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 import random
 import string
+import sys
 
 
 from pyparsing import alphanums, OneOrMore, Optional, Regex, Suppress, Word, QuotedString
@@ -1240,7 +1241,13 @@ class CephSaltConfigShell(configshell.ConfigShell):
                 os.remove(prefs_bin_path)
         else:
             logger.debug('%s does not exist', prefs_bin_path)
-        super(CephSaltConfigShell, self).__init__(configshell_path)
+        #
+        # initialize configshell_fb
+        try:
+            super(CephSaltConfigShell, self).__init__(configshell_path)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception("configshell_fb failed to initialize")
+            sys.exit("configshell_fb failed to initialize: {}".format(str(exc)))
         #
         # Grammar of the command line
         command = locatedExpr(Word(alphanums + '_'))('command')


### PR DESCRIPTION
config_shell: remove 0-length prefs.bin before init

Due to buggy behavior of configshell_fb, if the file

    ~/.ceph_salt_config_shell/prefs.bin

exists and has size 0, configshell_fb initialization will abort without any
helpful error message. This patch prevents the user from being exposed to this
(mis)behavior.

---

config_shell: handle configshell_fb init failure

configshell_fb init can fail, and when it did (before this patch), we were faced
with a sad situation: the user saw the following output:

    $ ceph-salt config

    Aborted!
    $

Beyond that, nothing (no log messages, either). This patch ensures that a useful
error message is displayed and the traceback gets logged to
/var/log/ceph-salt.log.
