### PR TITLE
ceph-salt-formula: use pkg.installed in apply only

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/software.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/software.sls
@@ -12,6 +12,7 @@ install required packages:
       - lsof
       - podman
       - rsync
+      - sudo
     - failhard: True
 
 /var/log/journal:

--- a/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
+++ b/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
@@ -14,10 +14,9 @@ create ssh user:
       - users
     - failhard: True
 
-install sudo:
-  pkg.installed:
-    - pkgs:
-      - sudo
+sudo sanity:
+  file.exists:
+    - name: /etc/sudoers.d
     - failhard: True
 
 configure sudoers:

--- a/ceph-salt-formula/salt/ceph-salt/reboot/reboot.sls
+++ b/ceph-salt-formula/salt/ceph-salt/reboot/reboot.sls
@@ -1,9 +1,8 @@
 {% import 'macros.yml' as macros %}
 
-install required packages:
-  pkg.installed:
-    - pkgs:
-      - lsof
+lsof sanity:
+  file.exists:
+    - name: /usr/bin/lsof
     - failhard: True
 
 {{ macros.begin_stage('Check if reboot is needed') }}

--- a/ceph-salt-formula/salt/ceph-salt/update/update.sls
+++ b/ceph-salt-formula/salt/ceph-salt/update/update.sls
@@ -2,10 +2,9 @@
 
 {{ macros.begin_stage('Update all packages') }}
 
-install required packages:
-  pkg.installed:
-    - pkgs:
-      - lsof
+lsof sanity:
+  file.exists:
+    - name: /usr/bin/lsof
     - failhard: True
 
 update packages:


### PR DESCRIPTION
It's not a good idea to put the pkg.installed state in sls files that will be
run often. This is because pkg.installed triggers a "zypper refresh" every time
it is run, and "zypper refresh" (a) takes a long time to run and (b) is prone to
failure.

Since we know that "ceph-salt apply" must completely successfully for ceph-salt
to be usable, we can move all pkg.installed invocations there. Elsewhere,
a simple file.exists check is enough to assert that the relevant RPM package is
still installed on the minion.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1177171
Signed-off-by: Nathan Cutler <ncutler@suse.com>