### PR TITLE
ceph-salt.spec: support salt 3002

### DIFF
--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -43,7 +43,8 @@ BuildRequires:  python3-setuptools
 %if 0%{?suse_version}
 Requires:       python3-click >= 6.7
 Requires:       python3-configshell-fb >= 1.1
-Requires:       python3-pycryptodomex >= 3.4.6
+Requires:       python3-distro >= 1.5.0
+Requires:       python3-pycryptodomex >= 3.9.8
 Requires:       python3-PyYAML >= 5.1.2
 Requires:       python3-setuptools
 Requires:       python3-salt >= 3000


### PR DESCRIPTION
For reasons that are not clear to me, ceph-salt will not work with
salt 3002 unless packages satisfying the following conditions are installed:

python3-pycrytpodomex >= 3.9.8
python3-distro >= 1.5.0

Partially fixes: https://bugzilla.suse.com/show_bug.cgi?id=1181611
Signed-off-by: Nathan Cutler <ncutler@suse.com>