### PR TITLE
ceph-salt-formula/cephbootstrap: drop --container-init

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -106,7 +106,6 @@ run cephadm bootstrap:
                 --allow-fqdn-hostname \
                 --apply-spec {{ bootstrap_spec_yaml_tmpfile }} \
                 --config {{ bootstrap_ceph_conf_tmpfile }} \
-                --container-init \
 {%- if not pillar['ceph-salt']['dashboard']['password_update_required'] %}
                 --dashboard-password-noupdate \
 {%- endif %}


### PR DESCRIPTION
As of 15.2.13, --container-init no longer works and --init is to be used
instead.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1188979
Signed-off-by: Nathan Cutler <ncutler@suse.com>