### PR TITLE
ceph-salt-formula: Fix admin labels

### DIFF
--- a/ceph-salt-formula/salt/_states/ceph_orch.py
+++ b/ceph-salt-formula/salt/_states/ceph_orch.py
@@ -80,7 +80,7 @@ def wait_until_ceph_orch_available(name, timeout=1800):
     ret['result'] = True
     return ret
 
-def add_host(name, host):
+def add_host(name, host, is_admin=False):
     """
     Requires the following grains to be set:
       - ceph-salt:execution:admin_host
@@ -89,7 +89,10 @@ def add_host(name, host):
     admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
     cmd_ret = __salt__['ceph_salt.ssh'](
                        admin_host,
-                       "sudo ceph orch host add {}".format(host),
+                       "sudo ceph orch host add {}{}".format(
+                           host,
+                           ' --labels _admin' if is_admin else '',
+                        ),
                        attempts=10)
     if cmd_ret['retcode'] == 0:
         ret['result'] = True

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephorch.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephorch.sls
@@ -3,12 +3,19 @@
 {% if 'cephadm' in grains['ceph-salt']['roles'] %}
 
 {% set my_hostname = salt['ceph_salt.hostname']() %}
+{% set is_admin = 'admin' in grains['ceph-salt']['roles'] %}
 
 {{ macros.begin_stage('Add host to ceph orchestrator') }}
 add host to ceph orch:
   ceph_orch.add_host:
     - host: {{ my_hostname }}
+    - is_admin: {{ is_admin }}
     - failhard: True
 {{ macros.end_stage('Add host to ceph orchestrator') }}
+
+{% else %}
+
+no op:
+  test.nop
 
 {% endif %}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,lint
+envlist = py3,lint
 minversion = 2.0
 skipsdist = True
 


### PR DESCRIPTION
Changes in this PR fix adding admin labels to the hosts when a host has the `admin` role assigned. It resolves https://github.com/SUSE/sesdev/issues/605. Clusters deployed with ceph-salt will also have the `_admin` label preserved, which they seemingly haven't before, although a multi-node deployment didn't fail due to that, whereas single-node deployment of a Ceph *Pacific* cluster in sesdev did fail.

Snippet of error in sesdev:

```sh
    # ...
    master: [2021-08-18 15:30:32.041831] [master.pacific-f] [STAGE] [END  ] Add host to ceph orchestrator
    master: [2021-08-18 15:30:32.052374] [master.pacific-f] [STAGE] [BEGIN] Ensure cephadm MGR module is configured
    master: [2021-08-18 15:30:33.306293] [master.pacific-f] Finished with failures
    master: Failure in minion: master.pacific-fail.test
    master: __id__: configure cephadm mgr module
    master: __run_num__: 109
    master: __sls__: ceph-salt.apply.ceph-admin
    master: changes:
    master:   pid: 38524
    master:   retcode: 1
    master:   stderr: 'Error initializing cluster client: ObjectNotFound(''RADOS object not found
    master:     (error calling conf_read_file)'',)
    master: 
    master:     Error initializing cluster client: ObjectNotFound(''RADOS object not found (error
    master:     calling conf_read_file)'',)
    master: 
    master:     Error initializing cluster client: ObjectNotFound(''RADOS object not found (error
    master:     calling conf_read_file)'',)
    master: 
    master:     Error initializing cluster client: ObjectNotFound(''RADOS object not found (error
    master:     calling conf_read_file)'',)
    master: 
    master:     Error initializing cluster client: ObjectNotFound(''RADOS object not found (error
    master:     calling conf_read_file)'',)'
    master:   stdout: value unchanged
    master: comment: 'Command "ceph cephadm set-priv-key -i /home/cephadm/.ssh/id_rsa
    master: 
    master:   ceph cephadm set-pub-key -i /home/cephadm/.ssh/id_rsa.pub
    master: 
    master:   ceph cephadm set-user cephadm
    # ...
```
Reproducer: `sesdev create pacific --single-node`

Reproducer for fix: `sesdev create pacific --single-node --ceph-salt-repo=https://github.com/p-se/ceph-salt.git --ceph-salt-branch=fix-single-node-deployment`.

Is related to https://github.com/ceph/ceph/pull/42772/files, which could also possibly fix the single-node deployment in sesdev (and ceph-salt), but might not work properly with multiple admin nodes (but I haven't tested that). I however think that being explicit in ceph-salt is appropriate.