### PR TITLE
Rely on cephadm package for cephadm user creation

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -38,12 +38,13 @@ def ssh(host, cmd, attempts=1):
     assert attempts > 0
     attempts_count = 0
     retry = True
+    cephadm_home = __salt__['user.info']('cephadm')['home']
     while retry:
         ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
                                       "-o UserKnownHostsFile=/dev/null "
                                       "-o ConnectTimeout=30 "
-                                      "-i /home/cephadm/.ssh/id_rsa "
-                                      "cephadm@{} \"{}\"".format(host, cmd))
+                                      "-i {}/.ssh/id_rsa "
+                                      "cephadm@{} \"{}\"".format(cephadm_home, host, cmd))
         attempts_count += 1
         retcode = ret['retcode']
         # 255: Connection closed by remote host
@@ -60,12 +61,13 @@ def ssh(host, cmd, attempts=1):
 
 def sudo_rsync(src, dest, ignore_existing):
     ignore_existing_option = '--ignore-existing ' if ignore_existing else ''
+    cephadm_home = __salt__['user.info']('cephadm')['home']
     return __salt__['cmd.run_all']("sudo rsync --rsync-path='sudo rsync' "
                                    "-e 'ssh -o StrictHostKeyChecking=no "
                                    "-o UserKnownHostsFile=/dev/null "
                                    "-o ConnectTimeout=30 "
-                                   "-i /home/cephadm/.ssh/id_rsa' "
-                                   "{}{} {} ".format(ignore_existing_option, src, dest))
+                                   "-i {}/.ssh/id_rsa' "
+                                   "{}{} {} ".format(cephadm_home, ignore_existing_option, src, dest))
 
 
 def get_remote_grain(host, grain):

--- a/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
@@ -9,8 +9,8 @@
 configure cephadm mgr module:
   cmd.run:
     - name: |
-        ceph cephadm set-priv-key -i /home/cephadm/.ssh/id_rsa
-        ceph cephadm set-pub-key -i /home/cephadm/.ssh/id_rsa.pub
+        ceph cephadm set-priv-key -i {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa
+        ceph cephadm set-pub-key -i {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa.pub
         ceph cephadm set-user cephadm
 {%- if auth %}
         ceph cephadm registry-login -i /tmp/ceph-salt-registry-json

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -120,8 +120,8 @@ run cephadm bootstrap:
                 --skip-monitoring-stack \
                 --skip-prepare-host \
                 --skip-pull \
-                --ssh-private-key /home/cephadm/.ssh/id_rsa \
-                --ssh-public-key /home/cephadm/.ssh/id_rsa.pub \
+                --ssh-private-key {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa \
+                --ssh-public-key {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa.pub \
                 --ssh-user cephadm \
 {%- for arg, value in pillar['ceph-salt'].get('bootstrap_arguments', {}).items() %}
                 --{{ arg }} {{ value if value is not none else '' }} \

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephconfigure.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephconfigure.sls
@@ -28,8 +28,8 @@ copy ceph.conf and keyring from admin node:
 enable cephadm mgr module:
   cmd.run:
     - name: |
-        ceph config-key set mgr/cephadm/ssh_identity_key -i /home/cephadm/.ssh/id_rsa
-        ceph config-key set mgr/cephadm/ssh_identity_pub -i /home/cephadm/.ssh/id_rsa.pub
+        ceph config-key set mgr/cephadm/ssh_identity_key -i {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa
+        ceph config-key set mgr/cephadm/ssh_identity_pub -i {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa.pub
         ceph config-key set mgr/cephadm/ssh_user cephadm
         ceph mgr module enable cephadm && \
         ceph orch set backend cephadm

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
@@ -4,17 +4,16 @@
 
 {{ macros.begin_stage('Configure cephadm') }}
 
-{{ macros.begin_step('Install cephadm and other ceph packages') }}
+{{ macros.begin_step('Install ceph packages') }}
 
 install cephadm:
   pkg.installed:
     - pkgs:
-        - cephadm
         - ceph-base
         - ceph-common
     - failhard: True
 
-{{ macros.end_step('Install cephadm and other ceph packages') }}
+{{ macros.end_step('Install ceph packages') }}
 
 {{ macros.begin_step('Run "cephadm check-host"') }}
 

--- a/ceph-salt-formula/salt/ceph-salt/apply/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/init.sls
@@ -1,5 +1,24 @@
 {% if grains['id'] in pillar['ceph-salt']['minions']['all'] %}
 
+# This little hack ensures that the cephadm package is installed at jinja
+# *compile* time on all salt minions.  The cephadm package itself ensures
+# the cephadm user and group are created, so we'll be able to rely on those
+# things existing later when the states are applied to pick up the correct
+# home directory, gid, etc.  The fact that the next line is a comment
+# doesn't matter, it'll still be expanded at jinja compile time and the
+# package will be installed correctly (either that or it'll fail with an
+# appropriate error message if the package can't be installed for some
+# reason).
+#
+# {{ salt['pkg.install']('cephadm') }}
+#
+# One irritation is that ideally, cephadm would only be installed on nodes
+# with the cephadm role.  Unfortunately, ceph-salt uses the cephadm user's
+# ssh keys to ssh between nodes to do things like check if grains are set
+# on remote hosts (e.g. when setting up time sync).  This means we need the
+# cephadm package installed everywhere to ensure the user and home directory
+# are present.
+
 include:
     - ..reset
     - ..common.sshkey

--- a/ceph-salt-formula/salt/ceph-salt/common/sshkey-cleanup.sls
+++ b/ceph-salt-formula/salt/ceph-salt/common/sshkey-cleanup.sls
@@ -2,12 +2,12 @@
 
 remove ceph-salt-ssh-id_rsa:
   file.absent:
-    - name: /home/cephadm/.ssh/id_rsa
+    - name: {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa
     - failhard: True
 
 remove ceph-salt-ssh-id_rsa.pub:
   file.absent:
-    - name: /home/cephadm/.ssh/id_rsa.pub
+    - name: {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa.pub
     - failhard: True
 
 {% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
+++ b/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
@@ -2,18 +2,6 @@
 
 {{ macros.begin_stage('Ensure SSH keys are configured') }}
 
-create ssh user group:
-  group.present:
-    - name: users
-
-create ssh user:
-  user.present:
-    - name: cephadm
-    - home: /home/cephadm
-    - groups:
-      - users
-    - failhard: True
-
 install sudo:
   pkg.installed:
     - pkgs:
@@ -34,9 +22,9 @@ configure sudoers:
 # make sure .ssh is present with the right permissions
 create ssh dir:
   file.directory:
-    - name: /home/cephadm/.ssh
+    - name: {{ salt['user.info']('cephadm').home }}/.ssh
     - user: cephadm
-    - group: users
+    - group: {{ salt['user.info']('cephadm').gid }}
     - mode: '0700'
     - makedirs: True
     - failhard: True
@@ -44,9 +32,9 @@ create ssh dir:
 # private key
 create ceph-salt-ssh-id_rsa:
   file.managed:
-    - name: /home/cephadm/.ssh/id_rsa
+    - name: {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa
     - user: cephadm
-    - group: users
+    - group: {{ salt['user.info']('cephadm').gid }}
     - mode: '0600'
     - contents_pillar: ceph-salt:ssh:private_key
     - failhard: True
@@ -54,9 +42,9 @@ create ceph-salt-ssh-id_rsa:
 # public key
 create ceph-salt-ssh-id_rsa.pub:
   file.managed:
-    - name: /home/cephadm/.ssh/id_rsa.pub
+    - name: {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa.pub
     - user: cephadm
-    - group: users
+    - group: {{ salt['user.info']('cephadm').gid }}
     - mode: '0644'
     - contents_pillar: ceph-salt:ssh:public_key
     - failhard: True


### PR DESCRIPTION
Rather than having ceph-salt create the cephadm user and group (with
home directory and gid inconsistent with the user the cephadm package
itself wants to create), we're now installing the cephadm package on
all minions, and relying on *it* to create the user and group.
ceph-salt will then pick up the cephadm user's home directory
automatically.

For new deployments, this will result in the cephadm user created as
a system user with gid=cephadm home=/var/lib/ceph as expected.  For
existing deployments upgraded from previous versions of ceph-salt,
everything continues to work with the old, existing, cephadm user
(home=/home/cephadm, gid=users), because we're now just picking up
the user's attributes at runtime, rather than hard-coding them.

Fixes: https://github.com/ceph/ceph-salt/issues/460
Signed-off-by: Tim Serong <tserong@suse.com>