### PR TITLE
tests: add source dir as real directory to fake fs

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 import json
 import pytest
 
+import Cryptodome
 import yaml
 from mock import patch
 from pyfakefs.fake_filesystem_unittest import TestCase
@@ -269,6 +270,9 @@ class SaltMockTestCase(TestCase):
     def setUp(self):
         super(SaltMockTestCase, self).setUp()
         self.setUpPyfakefs()
+        # Make sure tests can access real files inside the source tree
+        # (needed specifically for Cryptodome's dynamic library loading)
+        self.fs.add_real_directory(os.path.dirname(Cryptodome.__file__))
         self.local_fs = self.fs
 
         logger.info("Initializing Salt mocks")


### PR DESCRIPTION
We use Cryptodome for generating SSH keys, and that in turn tries to
dynamically load a shared library to do the work.  Recently (2021-09-19)
the load_pycryptodome_raw_lib() function was changed to use os.path.isfile()
to check if the shared library exists before loading it:

https://github.com/Legrandin/pycryptodome/commit/47bca2b38665696d932df487f49a17b240f9c886

The os.path.isfile() check fails when used inside a pytest environment
with a pyfakefs present (which of course we have in our unit tests).
We can work around this by calling add_real_directory() to add the real
source directory to the fakefs, so the os.path.isfile() test will pass.

Signed-off-by: Tim Serong <tserong@suse.com>