### PR TITLE
_modules/ceph_salt: log SSH commands

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -39,12 +39,14 @@ def ssh(host, cmd, attempts=1):
     attempts_count = 0
     retry = True
     cephadm_home = __salt__['user.info']('cephadm')['home']
+    full_cmd = ("ssh -o StrictHostKeyChecking=no "
+                "-o UserKnownHostsFile=/dev/null "
+                "-o ConnectTimeout=30 "
+                "-i {}/.ssh/id_rsa "
+                "cephadm@{} \"{}\"".format(cephadm_home, host, cmd))
+    log.info("ceph_salt.ssh: running SSH command {}".format(full_cmd))
     while retry:
-        ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                      "-o UserKnownHostsFile=/dev/null "
-                                      "-o ConnectTimeout=30 "
-                                      "-i {}/.ssh/id_rsa "
-                                      "cephadm@{} \"{}\"".format(cephadm_home, host, cmd))
+        ret = __salt__['cmd.run_all'](full_cmd)
         attempts_count += 1
         retcode = ret['retcode']
         # 255: Connection closed by remote host


### PR DESCRIPTION
For reproducing bugs, it can be useful to be able to see exactly which
commands ceph-salt is running.

Signed-off-by: Nathan Cutler <ncutler@suse.com>