### PR TITLE
ceph-salt-formula: give explicit IP addr when adding host

### DIFF
--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -184,6 +184,10 @@ def hostname():
     return socket.gethostname()
 
 
+def ip_address():
+    return socket.gethostbyname(socket.gethostname())
+
+
 def probe_fqdn():
     """
     Returns 'YES' if FQDN environment detected, 'NO' if not detected, or 'FAIL'

--- a/ceph-salt-formula/salt/_states/ceph_orch.py
+++ b/ceph-salt-formula/salt/_states/ceph_orch.py
@@ -80,7 +80,7 @@ def wait_until_ceph_orch_available(name, timeout=1800):
     ret['result'] = True
     return ret
 
-def add_host(name, host, is_admin=False):
+def add_host(name, host, ipaddr, is_admin=False):
     """
     Requires the following grains to be set:
       - ceph-salt:execution:admin_host
@@ -89,9 +89,10 @@ def add_host(name, host, is_admin=False):
     admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
     cmd_ret = __salt__['ceph_salt.ssh'](
                        admin_host,
-                       "sudo ceph orch host add {}{}".format(
+                       "sudo ceph orch host add {} {}{}".format(
                            host,
-                           ' --labels _admin' if is_admin else '',
+                           ipaddr,
+                           ' _admin' if is_admin else '',
                         ),
                        attempts=10)
     if cmd_ret['retcode'] == 0:

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephorch.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephorch.sls
@@ -3,12 +3,14 @@
 {% if 'cephadm' in grains['ceph-salt']['roles'] %}
 
 {% set my_hostname = salt['ceph_salt.hostname']() %}
+{% set my_ipaddr = salt['ceph_salt.ip_address']() %}
 {% set is_admin = 'admin' in grains['ceph-salt']['roles'] %}
 
 {{ macros.begin_stage('Add host to ceph orchestrator') }}
 add host to ceph orch:
   ceph_orch.add_host:
     - host: {{ my_hostname }}
+    - ipaddr: {{ my_ipaddr }}
     - is_admin: {{ is_admin }}
     - failhard: True
 {{ macros.end_stage('Add host to ceph orchestrator') }}


### PR DESCRIPTION
The upstream cephadm developers recently added a commit - https://github.com/ceph/ceph/commit/0facfac91fd8f71e5a8b869d818e7c2b07b93516 - which was backported to pacific and was found to be causing our post-bootstrap "ceph orch host add" command to fail because we weren't specifying the IP address explicitly.

While the developers are now discussing whether the command really should fail in this way, it seems prudent to give our IP address here explicitly, since mgr/cephadm is going to try to resolve the hostname, anyway.

Fixes: https://github.com/ceph/ceph-salt/issues/463

Signed-off-by: Nathan Cutler <ncutler@suse.com>