### PR TITLE
Bump to v15.2.16

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,10 +19,10 @@ jobs:
         pip install -r requirements.txt
     - name: Lint with pylint
       run: |
-        pylint sesboot
+        pylint ceph_salt
     - name: Lint with pycodestyle
       run: |
-        pycodestyle sesboot
+        pycodestyle ceph_salt
     - name: Lint tests with pylint
       run: |
         pylint tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.2.16] - 2021-11-26
+### Added
+- _modules/ceph_salt: log SSH commands (#464)
+
+### Fixed
+- Move ceph-salt-registry-json creation to container.sls (#467)
+- Use `cephadm registry-login --registry-json` (#467)
+- Rely on cephadm package for cephadm user creation (#461)
+- README.md: Fix broken cephadm link (#455)
+- tests: add source dir as real directory to fake fs (#462)
+- .github/workflows/linting: use ceph_salt instead old name (#458)
+
 ## [15.2.15] - 2021-02-09
 ### Added
 - Add support for Salt 3002 (#449)
@@ -296,7 +308,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minimal README.
 - The CHANGELOG file.
 
-[Unreleased]: https://github.com/ceph/ceph-salt/compare/v15.2.14...HEAD
+[Unreleased]: https://github.com/ceph/ceph-salt/compare/v15.2.16...octopus
+[15.2.16]: https://github.com/ceph/ceph-salt/releases/tag/v15.2.16
 [15.2.15]: https://github.com/ceph/ceph-salt/releases/tag/v15.2.15
 [15.2.14]: https://github.com/ceph/ceph-salt/releases/tag/v15.2.14
 [15.2.13]: https://github.com/ceph/ceph-salt/releases/tag/v15.2.13

--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -38,12 +38,13 @@ def ssh(host, cmd, attempts=1):
     assert attempts > 0
     attempts_count = 0
     retry = True
+    cephadm_home = __salt__['user.info']('cephadm')['home']
     while retry:
         ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
                                       "-o UserKnownHostsFile=/dev/null "
                                       "-o ConnectTimeout=30 "
-                                      "-i /home/cephadm/.ssh/id_rsa "
-                                      "cephadm@{} \"{}\"".format(host, cmd))
+                                      "-i {}/.ssh/id_rsa "
+                                      "cephadm@{} \"{}\"".format(cephadm_home, host, cmd))
         attempts_count += 1
         retcode = ret['retcode']
         # 255: Connection closed by remote host
@@ -60,12 +61,13 @@ def ssh(host, cmd, attempts=1):
 
 def sudo_rsync(src, dest, ignore_existing):
     ignore_existing_option = '--ignore-existing ' if ignore_existing else ''
+    cephadm_home = __salt__['user.info']('cephadm')['home']
     return __salt__['cmd.run_all']("sudo rsync --rsync-path='sudo rsync' "
                                    "-e 'ssh -o StrictHostKeyChecking=no "
                                    "-o UserKnownHostsFile=/dev/null "
                                    "-o ConnectTimeout=30 "
-                                   "-i /home/cephadm/.ssh/id_rsa' "
-                                   "{}{} {} ".format(ignore_existing_option, src, dest))
+                                   "-i {}/.ssh/id_rsa' "
+                                   "{}{} {} ".format(cephadm_home, ignore_existing_option, src, dest))
 
 
 def get_remote_grain(host, grain):

--- a/ceph-salt-formula/salt/_modules/ceph_salt.py
+++ b/ceph-salt-formula/salt/_modules/ceph_salt.py
@@ -39,12 +39,14 @@ def ssh(host, cmd, attempts=1):
     attempts_count = 0
     retry = True
     cephadm_home = __salt__['user.info']('cephadm')['home']
+    full_cmd = ("ssh -o StrictHostKeyChecking=no "
+                "-o UserKnownHostsFile=/dev/null "
+                "-o ConnectTimeout=30 "
+                "-i {}/.ssh/id_rsa "
+                "cephadm@{} \"{}\"".format(cephadm_home, host, cmd))
+    log.info("ceph_salt.ssh: running SSH command {}".format(full_cmd))
     while retry:
-        ret = __salt__['cmd.run_all']("ssh -o StrictHostKeyChecking=no "
-                                      "-o UserKnownHostsFile=/dev/null "
-                                      "-o ConnectTimeout=30 "
-                                      "-i {}/.ssh/id_rsa "
-                                      "cephadm@{} \"{}\"".format(cephadm_home, host, cmd))
+        ret = __salt__['cmd.run_all'](full_cmd)
         attempts_count += 1
         retcode = ret['retcode']
         # 255: Connection closed by remote host

--- a/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/ceph-admin.sls
@@ -9,8 +9,8 @@
 configure cephadm mgr module:
   cmd.run:
     - name: |
-        ceph cephadm set-priv-key -i /home/cephadm/.ssh/id_rsa
-        ceph cephadm set-pub-key -i /home/cephadm/.ssh/id_rsa.pub
+        ceph cephadm set-priv-key -i {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa
+        ceph cephadm set-pub-key -i {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa.pub
         ceph cephadm set-user cephadm
 {%- if auth %}
         ceph cephadm registry-login -i /tmp/ceph-salt-registry-json

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -18,18 +18,6 @@
 
 {{ macros.begin_step('Login into registry') }}
 
-create ceph-salt-registry-json:
-  file.managed:
-    - name: /tmp/ceph-salt-registry-json
-    - source:
-        - salt://ceph-salt/files/registry-login-json.j2
-    - template: jinja
-    - user: root
-    - group: root
-    - mode: '0600'
-    - backup: minion
-    - failhard: True
-
 login into registry:
   cmd.run:
     - name: |

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -120,8 +120,8 @@ run cephadm bootstrap:
                 --skip-monitoring-stack \
                 --skip-prepare-host \
                 --skip-pull \
-                --ssh-private-key /home/cephadm/.ssh/id_rsa \
-                --ssh-public-key /home/cephadm/.ssh/id_rsa.pub \
+                --ssh-private-key {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa \
+                --ssh-public-key {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa.pub \
                 --ssh-user cephadm \
 {%- for arg, value in pillar['ceph-salt'].get('bootstrap_arguments', {}).items() %}
                 --{{ arg }} {{ value if value is not none else '' }} \

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephbootstrap.sls
@@ -34,9 +34,7 @@ login into registry:
   cmd.run:
     - name: |
         cephadm registry-login \
-        --registry-url {{ auth.get('registry') }} \
-        --registry-username {{ auth.get('username') }} \
-        --registry-password {{ auth.get('password') }}
+        --registry-json /tmp/ceph-salt-registry-json
     - failhard: True
 
 {{ macros.end_step('Login into registry') }}

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephconfigure.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephconfigure.sls
@@ -28,8 +28,8 @@ copy ceph.conf and keyring from admin node:
 enable cephadm mgr module:
   cmd.run:
     - name: |
-        ceph config-key set mgr/cephadm/ssh_identity_key -i /home/cephadm/.ssh/id_rsa
-        ceph config-key set mgr/cephadm/ssh_identity_pub -i /home/cephadm/.ssh/id_rsa.pub
+        ceph config-key set mgr/cephadm/ssh_identity_key -i {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa
+        ceph config-key set mgr/cephadm/ssh_identity_pub -i {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa.pub
         ceph config-key set mgr/cephadm/ssh_user cephadm
         ceph mgr module enable cephadm && \
         ceph orch set backend cephadm

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
@@ -4,17 +4,16 @@
 
 {{ macros.begin_stage('Configure cephadm') }}
 
-{{ macros.begin_step('Install cephadm and other ceph packages') }}
+{{ macros.begin_step('Install ceph packages') }}
 
 install cephadm:
   pkg.installed:
     - pkgs:
-        - cephadm
         - ceph-base
         - ceph-common
     - failhard: True
 
-{{ macros.end_step('Install cephadm and other ceph packages') }}
+{{ macros.end_step('Install ceph packages') }}
 
 {{ macros.begin_step('Run "cephadm check-host"') }}
 

--- a/ceph-salt-formula/salt/ceph-salt/apply/container.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/container.sls
@@ -21,4 +21,26 @@
 
 {% endif %}
 
+{% if grains['id'] == pillar['ceph-salt'].get('bootstrap_minion') or 'admin' in grains['ceph-salt']['roles'] %}
+{% set auth = pillar['ceph-salt'].get('container', {}).get('auth', {}) %}
+{% if auth %}
+{{ macros.begin_step('Set container registry credentials') }}
+
+create ceph-salt-registry-json:
+  file.managed:
+    - name: /tmp/ceph-salt-registry-json
+    - source:
+        - salt://ceph-salt/files/registry-login-json.j2
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: '0600'
+    - backup: minion
+    - failhard: True
+
+{{ macros.end_step('Set container registry credentials') }}
+{% endif %}
+{% endif %}
+
+
 {{ macros.end_stage('Set up container environment') }}

--- a/ceph-salt-formula/salt/ceph-salt/apply/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/init.sls
@@ -1,5 +1,24 @@
 {% if grains['id'] in pillar['ceph-salt']['minions']['all'] %}
 
+# This little hack ensures that the cephadm package is installed at jinja
+# *compile* time on all salt minions.  The cephadm package itself ensures
+# the cephadm user and group are created, so we'll be able to rely on those
+# things existing later when the states are applied to pick up the correct
+# home directory, gid, etc.  The fact that the next line is a comment
+# doesn't matter, it'll still be expanded at jinja compile time and the
+# package will be installed correctly (either that or it'll fail with an
+# appropriate error message if the package can't be installed for some
+# reason).
+#
+# {{ salt['pkg.install']('cephadm') }}
+#
+# One irritation is that ideally, cephadm would only be installed on nodes
+# with the cephadm role.  Unfortunately, ceph-salt uses the cephadm user's
+# ssh keys to ssh between nodes to do things like check if grains are set
+# on remote hosts (e.g. when setting up time sync).  This means we need the
+# cephadm package installed everywhere to ensure the user and home directory
+# are present.
+
 include:
     - ..reset
     - ..common.sshkey

--- a/ceph-salt-formula/salt/ceph-salt/common/sshkey-cleanup.sls
+++ b/ceph-salt-formula/salt/ceph-salt/common/sshkey-cleanup.sls
@@ -2,12 +2,12 @@
 
 remove ceph-salt-ssh-id_rsa:
   file.absent:
-    - name: /home/cephadm/.ssh/id_rsa
+    - name: {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa
     - failhard: True
 
 remove ceph-salt-ssh-id_rsa.pub:
   file.absent:
-    - name: /home/cephadm/.ssh/id_rsa.pub
+    - name: {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa.pub
     - failhard: True
 
 {% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
+++ b/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
@@ -2,18 +2,6 @@
 
 {{ macros.begin_stage('Ensure SSH keys are configured') }}
 
-create ssh user group:
-  group.present:
-    - name: users
-
-create ssh user:
-  user.present:
-    - name: cephadm
-    - home: /home/cephadm
-    - groups:
-      - users
-    - failhard: True
-
 install sudo:
   pkg.installed:
     - pkgs:
@@ -34,9 +22,9 @@ configure sudoers:
 # make sure .ssh is present with the right permissions
 create ssh dir:
   file.directory:
-    - name: /home/cephadm/.ssh
+    - name: {{ salt['user.info']('cephadm').home }}/.ssh
     - user: cephadm
-    - group: users
+    - group: {{ salt['user.info']('cephadm').gid }}
     - mode: '0700'
     - makedirs: True
     - failhard: True
@@ -44,9 +32,9 @@ create ssh dir:
 # private key
 create ceph-salt-ssh-id_rsa:
   file.managed:
-    - name: /home/cephadm/.ssh/id_rsa
+    - name: {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa
     - user: cephadm
-    - group: users
+    - group: {{ salt['user.info']('cephadm').gid }}
     - mode: '0600'
     - contents_pillar: ceph-salt:ssh:private_key
     - failhard: True
@@ -54,9 +42,9 @@ create ceph-salt-ssh-id_rsa:
 # public key
 create ceph-salt-ssh-id_rsa.pub:
   file.managed:
-    - name: /home/cephadm/.ssh/id_rsa.pub
+    - name: {{ salt['user.info']('cephadm').home }}/.ssh/id_rsa.pub
     - user: cephadm
-    - group: users
+    - group: {{ salt['user.info']('cephadm').gid }}
     - mode: '0644'
     - contents_pillar: ceph-salt:ssh:public_key
     - failhard: True

--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -21,7 +21,7 @@
 %endif
 
 Name:           ceph-salt
-Version:        15.2.15
+Version:        15.2.16
 Release:        1%{?dist}
 Summary:        CLI tool to deploy Ceph clusters
 License:        MIT

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 import json
 import pytest
 
+import Cryptodome
 import yaml
 from mock import patch
 from pyfakefs.fake_filesystem_unittest import TestCase
@@ -269,6 +270,9 @@ class SaltMockTestCase(TestCase):
     def setUp(self):
         super(SaltMockTestCase, self).setUp()
         self.setUpPyfakefs()
+        # Make sure tests can access real files inside the source tree
+        # (needed specifically for Cryptodome's dynamic library loading)
+        self.fs.add_real_directory(os.path.dirname(Cryptodome.__file__))
         self.local_fs = self.fs
 
         logger.info("Initializing Salt mocks")


### PR DESCRIPTION
Note that this is to release v15.2.16 based on the _octopus_ branch of ceph-salt. The master branch of ceph-salt should really be versioned 16.x. Nathan, Patrick and I discussed the branch split back in August, because there have been a couple of changes (#457 and #463) which are applicable for Pacific or newer, but not for Octopus, and the octopus branch was created to handle this, but we never did the 16.x version bump in the master branch.

Right now, I have a need to do a downstream Octopus-compatible release, so what I've done here in this PR is:

- Cherry-pick the commits I needed from master
- Updated the changelog and package version

Assuming everyone's happy with this, I'll merge this PR to the octopus branch and tag the result 15.2.16. Once that's done, I'll open another PR to update the changelog and bump the version of the master branch to 16.x.

Does this sound OK to everyone?