### PR TITLE
Bump to v16.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [16.2.0] - 2021-12-01
+### Added
+- Support deploying Ceph Pacific
+- ceph-salt-formula: Add hosts with admin label (#457)
+- ceph-salt-formula: give explicit IP addr when adding host (#465)
+
+### Fixed
+- Tox: Fix issues when running tox on Python 3.8 (#457)
+- Remove Travis CI (#459)
+- .github/workflows: add tox and more python versions (#458)
+
+## [15.2.16] - 2021-11-26
+### Added
+- _modules/ceph_salt: log SSH commands (#464)
+
+### Fixed
+- Move ceph-salt-registry-json creation to container.sls (#467)
+- Use `cephadm registry-login --registry-json` (#467)
+- Rely on cephadm package for cephadm user creation (#461)
+- README.md: Fix broken cephadm link (#455)
+- tests: add source dir as real directory to fake fs (#462)
+- .github/workflows/linting: use ceph_salt instead old name (#458)
+
 ## [15.2.15] - 2021-02-09
 ### Added
 - Add support for Salt 3002 (#449)
@@ -296,7 +319,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minimal README.
 - The CHANGELOG file.
 
-[Unreleased]: https://github.com/ceph/ceph-salt/compare/v15.2.14...HEAD
+[Unreleased]: https://github.com/ceph/ceph-salt/compare/v16.2.0...HEAD
+[16.2.0]: https://github.com/ceph/ceph-salt/releases/tag/v16.2.0
+[15.2.16]: https://github.com/ceph/ceph-salt/releases/tag/v15.2.16
 [15.2.15]: https://github.com/ceph/ceph-salt/releases/tag/v15.2.15
 [15.2.14]: https://github.com/ceph/ceph-salt/releases/tag/v15.2.14
 [15.2.13]: https://github.com/ceph/ceph-salt/releases/tag/v15.2.13

--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -21,7 +21,7 @@
 %endif
 
 Name:           ceph-salt
-Version:        15.2.15
+Version:        16.2.0
 Release:        1%{?dist}
 Summary:        CLI tool to deploy Ceph clusters
 License:        MIT


### PR DESCRIPTION
As mentioned in #468, this brings master up to version 16.2.0, and incorporates the 15.2.16 changelog entries.

~The one thing I wasn't certain about was the exact version to set. I note that the 15 series went 15.0.x, then later 15.1.x, then 15.2.x, I assume following the ceph versioning convention of x.0.y being dev, x.1.y being RC and x.2.y being stable. On the assumption that we may still have further work to do to ceph-salt to support pacific releases I've called this 16.0.0. Does that sound sensible?~