### PR TITLE
config the ssh key after package install/upgrade

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/update/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/update/init.sls
@@ -2,8 +2,8 @@
 
 include:
     - ..reset
-    - ..common.sshkey
     - .update
+    - ..common.sshkey
     - .update-end
 
 {% else %}


### PR DESCRIPTION
upgrade of the `cephadm` package will empty the `authorized_keys` file

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1196938
Signed-off-by: Michael Fritch <mfritch@suse.com>