### PR TITLE
octopus: add the orchestrator `_admin` host label during `ceph-salt update`

### DIFF
--- a/ceph-salt-formula/salt/_states/ceph_orch.py
+++ b/ceph-salt-formula/salt/_states/ceph_orch.py
@@ -97,6 +97,25 @@ def add_host(name, host):
         ret['comment'] = cmd_ret.get('stderr')
     return ret
 
+def add_host_label(name, host, label):
+    """
+    Requires the following grains to be set:
+      - ceph-salt:execution:admin_host
+    """
+    ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
+    admin_host = __salt__['grains.get']('ceph-salt:execution:admin_host')
+    cmd_ret = __salt__['ceph_salt.ssh'](
+                       admin_host,
+                       "sudo ceph orch host label add {} {}".format(
+                           host,
+                           label,
+                        ),
+                       attempts=10)
+    if cmd_ret['retcode'] == 0:
+        ret['result'] = True
+    else:
+        ret['comment'] = cmd_ret.get('stderr')
+    return ret
 
 def rm_clusters(name):
     """

--- a/ceph-salt-formula/salt/ceph-salt/common/orch-host-label.sls
+++ b/ceph-salt-formula/salt/ceph-salt/common/orch-host-label.sls
@@ -1,0 +1,20 @@
+{% import 'macros.yml' as macros %}
+
+{% set my_hostname = salt['ceph_salt.hostname']() %}
+
+{% if 'admin' in grains['ceph-salt']['roles'] %}
+
+{{ macros.begin_stage('Add host labels to ceph orchestrator') }}
+add _admin host label to ceph orch:
+  ceph_orch.add_host_label:
+    - host: {{ my_hostname }}
+    - label: {{ '_admin' }}
+    - failhard: True
+{{ macros.end_stage('Add host labels to ceph orchestrator') }}
+
+{% else %}
+
+not an admin role:
+  test.nop
+
+{% endif %}

--- a/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
+++ b/ceph-salt-formula/salt/ceph-salt/common/sshkey.sls
@@ -14,6 +14,7 @@ configure sudoers:
     - text:
       - "cephadm ALL=NOPASSWD: /usr/bin/ceph -s"
       - "cephadm ALL=NOPASSWD: /usr/bin/ceph orch host add *"
+      - "cephadm ALL=NOPASSWD: /usr/bin/ceph orch host label *"
       - "cephadm ALL=NOPASSWD: /usr/bin/ceph orch host ok-to-stop *"
       - "cephadm ALL=NOPASSWD: /usr/bin/ceph orch status --format=json"
       - "cephadm ALL=NOPASSWD: /usr/bin/python3"

--- a/ceph-salt-formula/salt/ceph-salt/update/update-end.sls
+++ b/ceph-salt-formula/salt/ceph-salt/update/update-end.sls
@@ -1,5 +1,6 @@
 include:
     - ..common.sshkey-cleanup
+    - ..common.orch-host-label
 
 set updated:
   grains.present:


### PR DESCRIPTION
backport of #476

320e2d4e08248569b15ebe4e372a4e76afdfeea6 introduced the concept of
adding orchestrator host labels during `ceph-salt apply`, but
existing clusters will have already added hosts without this label

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1197188
Signed-off-by: Michael Fritch <mfritch@suse.com>