### PR TITLE
Add OS and Ceph version info to `ceph-salt status` output

### DIFF
--- a/ceph_salt/config_shell.py
+++ b/ceph_salt/config_shell.py
@@ -1283,20 +1283,43 @@ def run_status():
     result = True
     host_ls = CephOrch.host_ls()
     all = PillarManager.get('ceph-salt:minions:all', [])
-    status['cluster'] = '{} minions, {} hosts managed by cephadm'.format(len(all), len(host_ls))
+    all.sort()
+    status['Cluster'] = '{} minions, {} hosts managed by cephadm'.format(len(all), len(host_ls))
     deployed = CephOrch.deployed()
     nodes = {}
+    os_codenames = {}
+    ceph_versions = {}
     for minion in all:
         nodes[minion] = CephNode(minion)
+        os_codenames[minion] = nodes[minion].os_codename
+        ceph_versions[minion] = nodes[minion].ceph_version.split(' (')[0]
+    if len(set(os_codenames.values())) == 1:
+        status['OS'] = next(iter(os_codenames.values()))
+    else:
+        status['OS'] = PP.orange('Multiple versions running:\n')
+        lines = []
+        for ver in set(os_codenames.values()):
+            lines.append('           - {}:'.format(ver))
+            lines.extend(['             - ' + m for m in os_codenames if os_codenames[m] == ver])
+        status['OS'] += '\n'.join(lines)
+    if len(set(ceph_versions.values())) == 1:
+        status['Ceph RPMs'] = next(iter(ceph_versions.values()))
+    else:
+        status['Ceph RPMs'] = PP.orange('Multiple versions installed:\n')
+        lines = []
+        for ver in set(ceph_versions.values()):
+            lines.append('           - {}:'.format(ver))
+            lines.extend(['             - ' + m for m in ceph_versions if ceph_versions[m] == ver])
+        status['Ceph RPMs'] += '\n'.join(lines)
     error_msg = validate_config(deployed, nodes)
     if error_msg:
         result = False
         logger.info(error_msg)
-        status['config'] = PP.red(error_msg)
+        status['Config'] = PP.red(error_msg)
     else:
-        status['config'] = PP.green("OK")
+        status['Config'] = PP.green("OK")
     for k, v in status.items():
-        PP.println('{}{}'.format('{}: '.format(k).ljust(9), v))
+        PP.println('{}{}'.format('{}: '.format(k).ljust(11), v))
     return result
 
 

--- a/ceph_salt/core.py
+++ b/ceph_salt/core.py
@@ -28,6 +28,8 @@ class CephNode:
         self._public_ip = None
         self._subnets = None
         self._public_subnet = None
+        self._os_codename = None
+        self._ceph_version = None
 
     @property
     def ipsv4(self):
@@ -100,6 +102,22 @@ class CephNode:
             if 'execution' in result[self.minion_id]:
                 self._execution = result[self.minion_id]['execution']
         return self._execution
+
+    @property
+    def os_codename(self):
+        if self._os_codename is None:
+            result = GrainsManager.get_grain(self.minion_id, 'oscodename')
+            self._os_codename = result[self.minion_id]
+        return self._os_codename
+
+    @property
+    def ceph_version(self):
+        if self._ceph_version is None:
+            result = SaltClient.local_cmd(self.minion_id, 'cmd.shell', [
+                'test -e /usr/bin/ceph && ceph --version || echo "Not installed"'
+            ])
+            self._ceph_version = result[self.minion_id]
+        return self._ceph_version
 
     def add_role(self, role):
         self.roles.add(role)


### PR DESCRIPTION
This allows the admin to easily see that the same base OS version and Ceph packages are installed across the cluster.  Initially, before deployment, you'll see something like this:
```
# ceph-salt status
Cluster:   1 minions, 0 hosts managed by cephadm
OS:        SUSE Linux Enterprise Server 15 SP2
Ceph RPMs: Not installed
Config:    OK
```
Later, when deployed:
```
# ceph-salt status
Cluster:   4 minions, 4 hosts managed by cephadm
OS:        SUSE Linux Enterprise Server 15 SP2
Ceph RPMs: ceph version 15.2.15-83-gf72054fa653
Config:    OK
```
If you somehow manage to end up with mixed versions installed
while upgrading the base OS, you'll see something like this:
```
master:~ # ceph-salt status
Cluster:   4 minions, 4 hosts managed by cephadm
OS:        Multiple versions running:
           - SUSE Linux Enterprise Server 15 SP3:
             - master.ses7.test
             - node1.ses7.test
           - SUSE Linux Enterprise Server 15 SP2:
             - node2.ses7.test
             - node3.ses7.test
Ceph RPMs: Multiple versions installed:
           - ceph version 16.2.7-640-gceb23c7491b:
             - master.ses7.test
             - node1.ses7.test
           - ceph version 15.2.15-83-gf72054fa653:
             - node2.ses7.test
             - node3.ses7.test
Config:    OK
```
In the case where there are multiple versions, the strings "Multiple versions running" and "Multiple versions installed"
are rendered in orange to indicate that this is a slightly strange but non-fatal situation.

Signed-off-by: Tim Serong <tserong@suse.com>