### PR TITLE
Fix `ceph-salt update` when run prior to cluster deployment

### DIFF
--- a/ceph-salt-formula/salt/ceph-salt/apply/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/init.sls
@@ -1,25 +1,7 @@
 {% if grains['id'] in pillar['ceph-salt']['minions']['all'] %}
 
-# This little hack ensures that the cephadm package is installed at jinja
-# *compile* time on all salt minions.  The cephadm package itself ensures
-# the cephadm user and group are created, so we'll be able to rely on those
-# things existing later when the states are applied to pick up the correct
-# home directory, gid, etc.  The fact that the next line is a comment
-# doesn't matter, it'll still be expanded at jinja compile time and the
-# package will be installed correctly (either that or it'll fail with an
-# appropriate error message if the package can't be installed for some
-# reason).
-#
-# {{ salt['pkg.install']('cephadm') }}
-#
-# One irritation is that ideally, cephadm would only be installed on nodes
-# with the cephadm role.  Unfortunately, ceph-salt uses the cephadm user's
-# ssh keys to ssh between nodes to do things like check if grains are set
-# on remote hosts (e.g. when setting up time sync).  This means we need the
-# cephadm package installed everywhere to ensure the user and home directory
-# are present.
-
 include:
+    - ..common.install-cephadm
     - ..reset
     - ..common.sshkey
     - .sysctl

--- a/ceph-salt-formula/salt/ceph-salt/common/install-cephadm.sls
+++ b/ceph-salt-formula/salt/ceph-salt/common/install-cephadm.sls
@@ -1,0 +1,18 @@
+# This little hack ensures that the cephadm package is installed at jinja
+# *compile* time on all salt minions.  The cephadm package itself ensures
+# the cephadm user and group are created, so we'll be able to rely on those
+# things existing later when the states are applied to pick up the correct
+# home directory, gid, etc.  The fact that the next line is a comment
+# doesn't matter, it'll still be expanded at jinja compile time and the
+# package will be installed correctly (either that or it'll fail with an
+# appropriate error message if the package can't be installed for some
+# reason).
+#
+# {{ salt['pkg.install']('cephadm') }}
+#
+# One irritation is that ideally, cephadm would only be installed on nodes
+# with the cephadm role.  Unfortunately, ceph-salt uses the cephadm user's
+# ssh keys to ssh between nodes to do things like check if grains are set
+# on remote hosts (e.g. when setting up time sync).  This means we need the
+# cephadm package installed everywhere to ensure the user and home directory
+# are present.

--- a/ceph-salt-formula/salt/ceph-salt/common/orch-host-label.sls
+++ b/ceph-salt-formula/salt/ceph-salt/common/orch-host-label.sls
@@ -4,6 +4,7 @@
 
 {% if 'admin' in grains['ceph-salt']['roles'] %}
 
+{% if pillar['ceph-salt'].get ('execution', {}).get('deployed') != False %}
 {{ macros.begin_stage('Add host labels to ceph orchestrator') }}
 add _admin host label to ceph orch:
   ceph_orch.add_host_label:
@@ -11,6 +12,7 @@ add _admin host label to ceph orch:
     - label: {{ '_admin' }}
     - failhard: True
 {{ macros.end_stage('Add host labels to ceph orchestrator') }}
+{% endif %}
 
 {% else %}
 

--- a/ceph-salt-formula/salt/ceph-salt/update/init.sls
+++ b/ceph-salt-formula/salt/ceph-salt/update/init.sls
@@ -1,6 +1,7 @@
 {% if grains['id'] in pillar['ceph-salt']['minions']['all'] %}
 
 include:
+    - ..common.install-cephadm
     - ..reset
     - .update
     - ..common.sshkey

--- a/ceph_salt/execute.py
+++ b/ceph_salt/execute.py
@@ -1333,8 +1333,9 @@ class CephSaltExecutor:
         result = SaltClient.local_cmd('ceph-salt:member', 'state.sls_exists', [state],
                                       tgt_type='grain')
         if not all(result.values()):
-            PP.pl_red("Could not find {} formula. Please check if ceph-salt-formula package "
-                      "is installed".format(state))
+            PP.pl_red("Unable to use {state} formula. Please check if ceph-salt-formula "
+                      "package is installed. For more information try running "
+                      "`salt -G ceph-salt:member state.show_sls {state}`".format(state=state))
             return 7
 
         return 0


### PR DESCRIPTION
Three changes here:

1) Ensure cephadm package is installed during `ceph-salt update`
2) Only add _admin host labels during update if cluster is deployed
3) Add diagnostic hint in case of ceph-salt-formula errors

This'll want backporting to the octopus branch too.