### PR TITLE
Bump to v16.2.4, fix a couple of things

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         py:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [16.2.4] - 2022-12-19
 ### Fixed
+- Use daemon name rather than service type when stopping services
 - Run `saltutil.sync_runners` in ceph-salt-formula %post script (#486)
 - Don't explicitly install ceph-common (rely on ceph-base dependency)
+- Support monochrome terminals in `ceph-salt apply`
 
 ## [16.2.3] - 2022-04-14
 ### Fixed
@@ -339,7 +342,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minimal README.
 - The CHANGELOG file.
 
-[Unreleased]: https://github.com/ceph/ceph-salt/compare/v16.2.3...HEAD
+[Unreleased]: https://github.com/ceph/ceph-salt/compare/v16.2.4...HEAD
+[16.2.4]: https://github.com/ceph/ceph-salt/releases/tag/v16.2.4
 [16.2.3]: https://github.com/ceph/ceph-salt/releases/tag/v16.2.3
 [16.2.2]: https://github.com/ceph/ceph-salt/releases/tag/v16.2.2
 [16.2.1]: https://github.com/ceph/ceph-salt/releases/tag/v16.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Run `saltutil.sync_runners` in ceph-salt-formula %post script (#486)
+
 ## [16.2.3] - 2022-04-14
 ### Fixed
 - Fix ceph-salt update when run prior to cluster deployment (#482)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Run `saltutil.sync_runners` in ceph-salt-formula %post script (#486)
+- Don't explicitly install ceph-common (rely on ceph-base dependency)
 
 ## [16.2.3] - 2022-04-14
 ### Fixed

--- a/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
+++ b/ceph-salt-formula/salt/ceph-salt/apply/cephtools.sls
@@ -10,7 +10,6 @@ install cephadm:
   pkg.installed:
     - pkgs:
         - ceph-base
-        - ceph-common
     - failhard: True
 
 {{ macros.end_step('Install ceph packages') }}

--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -124,6 +124,10 @@ Requires(pre):  salt-master
 Salt Formula to deploy Ceph clusters.
 
 
+%post -n ceph-salt-formula
+# This is needed in order for the network.iperf runner to work
+salt-run --log-level warning saltutil.sync_runners || :
+
 %files -n ceph-salt-formula
 %defattr(-,root,root,-)
 %license LICENSE

--- a/ceph-salt.spec
+++ b/ceph-salt.spec
@@ -21,7 +21,7 @@
 %endif
 
 Name:           ceph-salt
-Version:        16.2.3
+Version:        16.2.4
 Release:        1%{?dist}
 Summary:        CLI tool to deploy Ceph clusters
 License:        MIT

--- a/ceph_salt/execute.py
+++ b/ceph_salt/execute.py
@@ -109,21 +109,24 @@ class CursesScreen:
         self.body_height = self.height - self.HEADER_HEIGHT - self.FOOTER_HEIGHT
         self.body_width = self.width - 1
         logger.info("current terminal size: rows=%s cols=%s", self.height, self.width)
-        curses.start_color()
-        curses.use_default_colors()
-
-        curses.init_pair(self.COLOR_MARKER, -1, -1)
-        curses.init_pair(self.COLOR_MINION, curses.COLOR_CYAN, -1)
-        curses.init_pair(self.COLOR_STAGE, curses.COLOR_YELLOW, -1)
-        curses.init_pair(self.COLOR_STEP, curses.COLOR_BLUE, -1)
-        curses.init_pair(self.COLOR_MENU, curses.COLOR_BLACK, curses.COLOR_GREEN)
-        curses.init_pair(self.COLOR_SUCCESS, curses.COLOR_GREEN, -1)
-        curses.init_pair(self.COLOR_ERROR, curses.COLOR_RED, -1)
-        curses.init_pair(self.COLOR_WARNING, curses.COLOR_YELLOW, -1)
+        try:
+            curses.start_color()
+            curses.use_default_colors()
+            curses.init_pair(self.COLOR_MARKER, -1, -1)
+            curses.init_pair(self.COLOR_MINION, curses.COLOR_CYAN, -1)
+            curses.init_pair(self.COLOR_STAGE, curses.COLOR_YELLOW, -1)
+            curses.init_pair(self.COLOR_STEP, curses.COLOR_BLUE, -1)
+            curses.init_pair(self.COLOR_MENU, curses.COLOR_BLACK, curses.COLOR_GREEN)
+            curses.init_pair(self.COLOR_SUCCESS, curses.COLOR_GREEN, -1)
+            curses.init_pair(self.COLOR_ERROR, curses.COLOR_RED, -1)
+            curses.init_pair(self.COLOR_WARNING, curses.COLOR_YELLOW, -1)
+            curses.curs_set(0)
+        except Exception:  # pylint: disable=broad-except
+            logger.warning("Unable to initialize curses color support (TERM=%s)",
+                           os.environ.get('TERM', 'not set'))
 
         curses.noecho()
         curses.cbreak()
-        curses.curs_set(0)
         self.stdscr.keypad(True)
 
         if self.height > 2:


### PR DESCRIPTION
Two fixes here:

* Run `saltutil.sync_runners` in ceph-salt-formula %post script
* Don't explicitly install ceph-common (rely on ceph-base dependency)