### PR TITLE
.github/workflows: drop python3.6 (not available anymore)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         py:
-          - 3.6
           - 3.8
 
     steps:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,8 +9,6 @@ jobs:
     strategy:
       matrix:
         include:
-        - tox-env: py36
-          py-ver: 3.6
         - tox-env: py38
           py-ver: 3.8
 


### PR DESCRIPTION
Signed-off-by: Tim Serong <tserong@suse.com>